### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  frontend:
+    name: Frontend Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test:run
+
+      - name: Build
+        run: npm run build
+
+  backend:
+    name: Backend Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run linter (ruff)
+        run: uv run ruff check .
+        continue-on-error: true
+
+      - name: Run type checker (mypy)
+        run: uv run mypy app --ignore-missing-imports
+        continue-on-error: true
+
+      - name: Run tests
+        run: uv run pytest tests/ -v
+        continue-on-error: true


### PR DESCRIPTION
## Summary
Add CI workflow that runs on push and PR to main branch.

## Frontend Jobs
- Install dependencies with npm ci
- Run ESLint via `next lint`
- Run vitest tests
- Build production bundle

## Backend Jobs
- Install uv and Python 3.11
- Sync dependencies
- Run ruff linter (optional - continues on error)
- Run mypy type checker (optional - continues on error)  
- Run pytest tests (optional - continues on error)

Backend checks are marked as optional initially since there may not be full test coverage or strict type checking configured yet.

## Test plan
- [ ] Push this PR and verify workflow runs
- [ ] Check frontend job passes all steps
- [ ] Backend job should run (may have failures that we'll address later)