### PR TITLE
feat: add transfer detection and management

### DIFF
--- a/backend/alembic/versions/59bd28abb36b_add_transfer_fields.py
+++ b/backend/alembic/versions/59bd28abb36b_add_transfer_fields.py
@@ -1,0 +1,31 @@
+"""add_transfer_fields
+
+Revision ID: 59bd28abb36b
+Revises: 4535a448d09f
+Create Date: 2025-11-29 20:23:40.093168
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '59bd28abb36b'
+down_revision = '4535a448d09f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add transfer detection fields to transactions
+    op.add_column('transactions', sa.Column('is_transfer', sa.Boolean(), nullable=False, server_default='0'))
+    op.add_column('transactions', sa.Column('linked_transaction_id', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_transactions_is_transfer'), 'transactions', ['is_transfer'], unique=False)
+    op.create_index(op.f('ix_transactions_linked_transaction_id'), 'transactions', ['linked_transaction_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_transactions_linked_transaction_id'), table_name='transactions')
+    op.drop_index(op.f('ix_transactions_is_transfer'), table_name='transactions')
+    op.drop_column('transactions', 'linked_transaction_id')
+    op.drop_column('transactions', 'is_transfer')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.database import init_db
-from app.routers import transactions, import_router, reports, budgets, tag_rules, recurring, admin, tags
+from app.routers import transactions, import_router, reports, budgets, tag_rules, recurring, admin, tags, transfers
 
 
 @asynccontextmanager
@@ -38,6 +38,7 @@ app.include_router(tag_rules.router)
 app.include_router(recurring.router)
 app.include_router(admin.router)
 app.include_router(tags.router)
+app.include_router(transfers.router)
 
 @app.get("/")
 async def root():

--- a/backend/app/routers/budgets.py
+++ b/backend/app/routers/budgets.py
@@ -164,6 +164,7 @@ async def get_spending_for_tag(
         return 0.0
 
     # Account tags use FK relationship, buckets/occasions use M2M junction table
+    # Exclude transfers from spending calculations
     if namespace == "account":
         # Accounts use direct FK (account_tag_id) on Transaction
         spending_result = await session.execute(
@@ -172,7 +173,8 @@ async def get_spending_for_tag(
                 Transaction.account_tag_id == tag.id,
                 Transaction.date >= start_date,
                 Transaction.date <= end_date,
-                Transaction.amount < 0  # Only expenses
+                Transaction.amount < 0,  # Only expenses
+                Transaction.is_transfer == False  # Exclude transfers
             )
         )
     else:
@@ -184,7 +186,8 @@ async def get_spending_for_tag(
                 TransactionTag.tag_id == tag.id,
                 Transaction.date >= start_date,
                 Transaction.date <= end_date,
-                Transaction.amount < 0  # Only expenses
+                Transaction.amount < 0,  # Only expenses
+                Transaction.is_transfer == False  # Exclude transfers
             )
         )
 

--- a/backend/app/routers/transfers.py
+++ b/backend/app/routers/transfers.py
@@ -1,0 +1,281 @@
+"""Transfer detection and management router"""
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List, Optional
+from datetime import datetime
+from pydantic import BaseModel
+import re
+
+from app.database import get_session
+from app.models import Transaction
+
+
+router = APIRouter(prefix="/api/v1/transfers", tags=["transfers"])
+
+
+# Patterns that indicate a transaction is likely a transfer
+TRANSFER_PATTERNS = [
+    r"(?i)payment.*thank",
+    r"(?i)autopay",
+    r"(?i)auto\s*pay",
+    r"(?i)online\s*(pmt|payment)",
+    r"(?i)transfer\s*(from|to)",
+    r"(?i)xfer",
+    r"(?i)ach.*payment",
+    r"(?i)bill\s*pay",
+    r"(?i)electronic\s*payment",
+    r"(?i)payment\s*received",
+    r"(?i)credit\s*card\s*payment",
+    r"(?i)bank\s*transfer",
+    r"(?i)wire\s*transfer",
+    r"(?i)internal\s*transfer",
+    r"(?i)funds\s*transfer",
+    r"(?i)mobile\s*deposit",  # Could be transfer from another account
+]
+
+# Compiled patterns for efficiency
+COMPILED_PATTERNS = [re.compile(p) for p in TRANSFER_PATTERNS]
+
+
+def is_likely_transfer(description: str, merchant: Optional[str] = None) -> bool:
+    """Check if a transaction looks like a transfer based on patterns"""
+    text_to_check = f"{description} {merchant or ''}"
+    return any(pattern.search(text_to_check) for pattern in COMPILED_PATTERNS)
+
+
+class MarkTransferRequest(BaseModel):
+    transaction_ids: List[int]
+    is_transfer: bool
+
+
+class LinkTransactionRequest(BaseModel):
+    linked_transaction_id: int
+
+
+class TransferSuggestion(BaseModel):
+    id: int
+    date: str
+    amount: float
+    description: str
+    merchant: Optional[str]
+    account_source: str
+    match_reason: str
+
+
+@router.get("/suggestions")
+async def get_transfer_suggestions(
+    limit: int = 50,
+    session: AsyncSession = Depends(get_session)
+):
+    """
+    Get transactions that look like transfers but aren't marked as such.
+    Useful for reviewing and confirming suggested transfers.
+    """
+    # Get transactions not already marked as transfer
+    result = await session.execute(
+        select(Transaction)
+        .where(Transaction.is_transfer == False)
+        .order_by(Transaction.date.desc())
+        .limit(500)  # Check more than we return to find matches
+    )
+    transactions = result.scalars().all()
+
+    suggestions = []
+    for txn in transactions:
+        if is_likely_transfer(txn.description, txn.merchant):
+            # Determine which pattern matched
+            text = f"{txn.description} {txn.merchant or ''}"
+            match_reason = "Pattern match"
+            for i, pattern in enumerate(COMPILED_PATTERNS):
+                if pattern.search(text):
+                    match_reason = f"Matches: {TRANSFER_PATTERNS[i]}"
+                    break
+
+            suggestions.append({
+                "id": txn.id,
+                "date": txn.date.isoformat(),
+                "amount": txn.amount,
+                "description": txn.description,
+                "merchant": txn.merchant,
+                "account_source": txn.account_source,
+                "match_reason": match_reason
+            })
+
+            if len(suggestions) >= limit:
+                break
+
+    return {
+        "count": len(suggestions),
+        "suggestions": suggestions
+    }
+
+
+@router.post("/mark")
+async def mark_as_transfer(
+    request: MarkTransferRequest,
+    session: AsyncSession = Depends(get_session)
+):
+    """
+    Mark one or more transactions as transfers (or unmark them).
+    Transfers are excluded from spending calculations.
+    """
+    if not request.transaction_ids:
+        raise HTTPException(status_code=400, detail="No transaction IDs provided")
+
+    # Fetch all transactions
+    result = await session.execute(
+        select(Transaction).where(Transaction.id.in_(request.transaction_ids))
+    )
+    transactions = result.scalars().all()
+
+    if len(transactions) != len(request.transaction_ids):
+        found_ids = {t.id for t in transactions}
+        missing_ids = set(request.transaction_ids) - found_ids
+        raise HTTPException(
+            status_code=404,
+            detail=f"Transactions not found: {list(missing_ids)}"
+        )
+
+    # Update all transactions
+    updated_count = 0
+    for txn in transactions:
+        if txn.is_transfer != request.is_transfer:
+            txn.is_transfer = request.is_transfer
+            txn.updated_at = datetime.utcnow()
+            updated_count += 1
+
+    await session.commit()
+
+    return {
+        "updated_count": updated_count,
+        "is_transfer": request.is_transfer,
+        "transaction_ids": request.transaction_ids
+    }
+
+
+@router.post("/{transaction_id}/link")
+async def link_transaction(
+    transaction_id: int,
+    request: LinkTransactionRequest,
+    session: AsyncSession = Depends(get_session)
+):
+    """
+    Link two transactions as a transfer pair (e.g., payment from checking
+    linked to payment received on credit card).
+    """
+    # Fetch both transactions
+    result = await session.execute(
+        select(Transaction).where(
+            Transaction.id.in_([transaction_id, request.linked_transaction_id])
+        )
+    )
+    transactions = {t.id: t for t in result.scalars().all()}
+
+    if transaction_id not in transactions:
+        raise HTTPException(status_code=404, detail=f"Transaction {transaction_id} not found")
+    if request.linked_transaction_id not in transactions:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Linked transaction {request.linked_transaction_id} not found"
+        )
+
+    txn1 = transactions[transaction_id]
+    txn2 = transactions[request.linked_transaction_id]
+
+    # Link them bidirectionally
+    txn1.linked_transaction_id = request.linked_transaction_id
+    txn2.linked_transaction_id = transaction_id
+
+    # Mark both as transfers
+    txn1.is_transfer = True
+    txn2.is_transfer = True
+
+    txn1.updated_at = datetime.utcnow()
+    txn2.updated_at = datetime.utcnow()
+
+    await session.commit()
+
+    return {
+        "message": "Transactions linked successfully",
+        "transaction_id": transaction_id,
+        "linked_transaction_id": request.linked_transaction_id
+    }
+
+
+@router.delete("/{transaction_id}/link")
+async def unlink_transaction(
+    transaction_id: int,
+    session: AsyncSession = Depends(get_session)
+):
+    """
+    Unlink a transaction from its paired transfer.
+    Does not change the is_transfer flag.
+    """
+    result = await session.execute(
+        select(Transaction).where(Transaction.id == transaction_id)
+    )
+    txn = result.scalar_one_or_none()
+
+    if not txn:
+        raise HTTPException(status_code=404, detail="Transaction not found")
+
+    if not txn.linked_transaction_id:
+        raise HTTPException(status_code=400, detail="Transaction is not linked")
+
+    # Get the linked transaction and unlink it too
+    linked_id = txn.linked_transaction_id
+    result = await session.execute(
+        select(Transaction).where(Transaction.id == linked_id)
+    )
+    linked_txn = result.scalar_one_or_none()
+
+    # Unlink both
+    txn.linked_transaction_id = None
+    txn.updated_at = datetime.utcnow()
+
+    if linked_txn and linked_txn.linked_transaction_id == transaction_id:
+        linked_txn.linked_transaction_id = None
+        linked_txn.updated_at = datetime.utcnow()
+
+    await session.commit()
+
+    return {
+        "message": "Transaction unlinked",
+        "transaction_id": transaction_id,
+        "previously_linked_to": linked_id
+    }
+
+
+@router.get("/stats")
+async def get_transfer_stats(
+    session: AsyncSession = Depends(get_session)
+):
+    """Get statistics about transfers"""
+    from sqlalchemy import func
+
+    # Count transfers
+    result = await session.execute(
+        select(func.count(Transaction.id)).where(Transaction.is_transfer == True)
+    )
+    transfer_count = result.scalar() or 0
+
+    # Sum transfer amounts (absolute value)
+    result = await session.execute(
+        select(func.sum(func.abs(Transaction.amount)))
+        .where(Transaction.is_transfer == True)
+    )
+    transfer_total = result.scalar() or 0.0
+
+    # Count linked pairs
+    result = await session.execute(
+        select(func.count(Transaction.id))
+        .where(Transaction.linked_transaction_id.isnot(None))
+    )
+    linked_count = result.scalar() or 0
+
+    return {
+        "transfer_count": transfer_count,
+        "transfer_total": round(transfer_total, 2),
+        "linked_pairs": linked_count // 2  # Divide by 2 since links are bidirectional
+    }

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -42,6 +42,9 @@ export default function RootLayout({
                   <Link href="/budgets" className="nav-link inline-flex items-center px-1 pt-1">
                     Budgets
                   </Link>
+                  <Link href="/transfers" className="nav-link inline-flex items-center px-1 pt-1">
+                    Transfers
+                  </Link>
                   <Link href="/rules" className="nav-link inline-flex items-center px-1 pt-1">
                     Rules
                   </Link>

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -35,6 +35,7 @@ interface Transaction {
   tags?: TransactionTag[]
   bucket?: string  // Convenience field we'll compute
   account?: string  // Convenience field we'll compute from account tag
+  is_transfer?: boolean  // True if marked as internal transfer
 }
 
 const PAGE_SIZE = 50
@@ -1024,7 +1025,12 @@ function TransactionsContent() {
                     </select>
 
                     <div className="flex items-center gap-1 ml-auto flex-shrink-0">
-                      <span className={`font-semibold text-sm ${txn.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
+                      {txn.is_transfer && (
+                        <span className="px-1.5 py-0.5 text-xs rounded bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300" title="Internal transfer - excluded from spending">
+                          Transfer
+                        </span>
+                      )}
+                      <span className={`font-semibold text-sm ${txn.is_transfer ? 'text-theme-muted' : txn.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
                         {formatCurrency(txn.amount, true)}
                       </span>
                       <button
@@ -1155,7 +1161,12 @@ function TransactionsContent() {
                         </p>
                       </div>
                       <div className="flex items-center gap-1">
-                        <span className={`font-semibold ${txn.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
+                        {txn.is_transfer && (
+                          <span className="px-1 py-0.5 text-xs rounded bg-blue-100 text-blue-700" title="Transfer">
+                            T
+                          </span>
+                        )}
+                        <span className={`font-semibold ${txn.is_transfer ? 'text-theme-muted' : txn.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
                           {formatCurrency(txn.amount, true)}
                         </span>
                         <button

--- a/frontend/src/app/transfers/page.tsx
+++ b/frontend/src/app/transfers/page.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { format } from 'date-fns'
+import { formatCurrency } from '@/lib/format'
+import { PageHelp } from '@/components/PageHelp'
+
+interface TransferSuggestion {
+  id: number
+  date: string
+  amount: number
+  description: string
+  merchant: string | null
+  account_source: string
+  match_reason: string
+}
+
+interface TransferStats {
+  transfer_count: number
+  transfer_total: number
+  linked_pairs: number
+}
+
+export default function TransfersPage() {
+  const [suggestions, setSuggestions] = useState<TransferSuggestion[]>([])
+  const [stats, setStats] = useState<TransferStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [processing, setProcessing] = useState(false)
+
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  async function fetchData() {
+    try {
+      const [suggestionsRes, statsRes] = await Promise.all([
+        fetch('/api/v1/transfers/suggestions?limit=100'),
+        fetch('/api/v1/transfers/stats')
+      ])
+
+      const suggestionsData = await suggestionsRes.json()
+      const statsData = await statsRes.json()
+
+      setSuggestions(suggestionsData.suggestions || [])
+      setStats(statsData)
+      setLoading(false)
+    } catch (error) {
+      console.error('Error fetching transfer data:', error)
+      setLoading(false)
+    }
+  }
+
+  function toggleSelection(id: number) {
+    const newSet = new Set(selectedIds)
+    if (newSet.has(id)) {
+      newSet.delete(id)
+    } else {
+      newSet.add(id)
+    }
+    setSelectedIds(newSet)
+  }
+
+  function selectAll() {
+    if (selectedIds.size === suggestions.length) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(suggestions.map(s => s.id)))
+    }
+  }
+
+  async function markAsTransfers() {
+    if (selectedIds.size === 0) return
+
+    setProcessing(true)
+    try {
+      await fetch('/api/v1/transfers/mark', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          transaction_ids: Array.from(selectedIds),
+          is_transfer: true
+        })
+      })
+
+      // Refresh data
+      setSelectedIds(new Set())
+      await fetchData()
+    } catch (error) {
+      console.error('Error marking transfers:', error)
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  async function dismissSuggestions() {
+    // Just remove from local state - they're not transfers
+    setSuggestions(suggestions.filter(s => !selectedIds.has(s.id)))
+    setSelectedIds(new Set())
+  }
+
+  if (loading) {
+    return <div className="text-center py-12">Loading...</div>
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHelp
+        pageId="transfers"
+        title="Transfer Detection Help"
+        description="Identify and mark internal transfers so they're excluded from spending reports. Transfers include credit card payments, bank-to-bank moves, etc."
+        steps={[
+          "Review suggested transfers detected by pattern matching",
+          "Select transactions that are actually transfers",
+          "Click 'Mark as Transfers' to exclude them from spending",
+          "Dismiss suggestions that aren't transfers"
+        ]}
+        tips={[
+          "Transfers are excluded from budgets and spending reports",
+          "You can link paired transfers (e.g., payment sent + payment received)",
+          "Suggestions are based on keywords like 'PAYMENT', 'TRANSFER', 'AUTOPAY'"
+        ]}
+      />
+
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-3xl font-bold text-theme">Transfer Detection</h1>
+          <p className="mt-2 text-sm text-theme-muted">
+            Identify internal transfers to exclude from spending calculations
+          </p>
+        </div>
+      </div>
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-3 gap-4">
+          <div className="card p-4">
+            <div className="text-sm text-theme-muted">Marked as Transfer</div>
+            <div className="text-2xl font-bold text-theme">{stats.transfer_count}</div>
+          </div>
+          <div className="card p-4">
+            <div className="text-sm text-theme-muted">Transfer Total</div>
+            <div className="text-2xl font-bold text-theme">{formatCurrency(stats.transfer_total)}</div>
+          </div>
+          <div className="card p-4">
+            <div className="text-sm text-theme-muted">Linked Pairs</div>
+            <div className="text-2xl font-bold text-theme">{stats.linked_pairs}</div>
+          </div>
+        </div>
+      )}
+
+      {/* Suggestions */}
+      <div className="card">
+        <div className="p-4 border-b border-theme flex justify-between items-center">
+          <div>
+            <h2 className="text-lg font-semibold text-theme">Suggested Transfers</h2>
+            <p className="text-sm text-theme-muted">
+              {suggestions.length} transactions look like internal transfers
+            </p>
+          </div>
+          {selectedIds.size > 0 && (
+            <div className="flex gap-2">
+              <button
+                onClick={dismissSuggestions}
+                className="px-3 py-1.5 text-sm border border-theme rounded-md hover:bg-theme-elevated"
+              >
+                Dismiss ({selectedIds.size})
+              </button>
+              <button
+                onClick={markAsTransfers}
+                disabled={processing}
+                className="btn-primary text-sm disabled:opacity-50"
+              >
+                {processing ? 'Processing...' : `Mark as Transfers (${selectedIds.size})`}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {suggestions.length === 0 ? (
+          <div className="p-8 text-center text-theme-muted">
+            No transfer suggestions found. All detected transfers have been processed.
+          </div>
+        ) : (
+          <div className="divide-y divide-theme">
+            {/* Header row */}
+            <div className="px-4 py-2 bg-theme-elevated flex items-center gap-4 text-sm font-medium text-theme-muted">
+              <input
+                type="checkbox"
+                checked={selectedIds.size === suggestions.length && suggestions.length > 0}
+                onChange={selectAll}
+                className="rounded"
+              />
+              <span className="w-24">Date</span>
+              <span className="w-28 text-right">Amount</span>
+              <span className="flex-1">Description</span>
+              <span className="w-32">Account</span>
+              <span className="w-48">Match Reason</span>
+            </div>
+
+            {suggestions.map((suggestion) => (
+              <div
+                key={suggestion.id}
+                className={`px-4 py-3 flex items-center gap-4 hover:bg-theme-elevated cursor-pointer ${
+                  selectedIds.has(suggestion.id) ? 'bg-theme-elevated' : ''
+                }`}
+                onClick={() => toggleSelection(suggestion.id)}
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(suggestion.id)}
+                  onChange={() => toggleSelection(suggestion.id)}
+                  onClick={(e) => e.stopPropagation()}
+                  className="rounded"
+                />
+                <span className="w-24 text-sm text-theme-muted">
+                  {format(new Date(suggestion.date), 'MMM d, yyyy')}
+                </span>
+                <span className={`w-28 text-right font-mono text-sm ${
+                  suggestion.amount < 0 ? 'text-negative' : 'text-positive'
+                }`}>
+                  {formatCurrency(suggestion.amount)}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm text-theme truncate">
+                    {suggestion.merchant || suggestion.description}
+                  </div>
+                  {suggestion.merchant && (
+                    <div className="text-xs text-theme-muted truncate">
+                      {suggestion.description}
+                    </div>
+                  )}
+                </div>
+                <span className="w-32 text-sm text-theme-muted truncate">
+                  {suggestion.account_source}
+                </span>
+                <span className="w-48 text-xs text-theme-muted truncate" title={suggestion.match_reason}>
+                  {suggestion.match_reason}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add transfer detection to identify internal transfers (CC payments, bank-to-bank moves)
- Transfers are excluded from spending calculations, budgets, and reports
- New `/transfers` page for reviewing and marking transfers

## Changes

### Backend
- **Model**: Add `is_transfer` and `linked_transaction_id` to Transaction
- **Router**: New `/api/v1/transfers` endpoints for suggestions, marking, linking, stats
- **Budgets**: Exclude transfers from spending calculations
- **Reports**: Exclude transfers from all spending reports (monthly, trends, velocity, anomalies)

### Frontend  
- New `/transfers` page with pattern-based suggestions
- Transfer badge indicator in transaction list
- Transfers nav link

## Test plan
- [ ] Visit /transfers page - should show suggested transfers
- [ ] Mark transactions as transfers - verify they disappear from suggestions
- [ ] Check budgets - transfers should not count toward spending
- [ ] Check dashboard/reports - transfers should be excluded
- [ ] Transaction list shows "Transfer" badge on marked items