### PR TITLE
feat: add Inspira HSA and Venmo CSV import formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,11 +272,16 @@ check-deps: ## Check if required dependencies are installed
 # Docker targets
 # =============================================================================
 
-.PHONY: docker-build docker-up docker-down docker-logs docker-shell
+.PHONY: docker-build docker-build-force docker-up docker-down docker-logs docker-shell
 
 docker-build: ## Build Docker image
 	@echo "$(BLUE)Building Docker image...$(NC)"
 	docker compose build
+	@echo "$(GREEN)✓ Docker image built$(NC)"
+
+docker-build-force: ## Build Docker image (no cache)
+	@echo "$(BLUE)Building Docker image (no cache)...$(NC)"
+	docker compose build --no-cache
 	@echo "$(GREEN)✓ Docker image built$(NC)"
 
 docker-up: ## Start Docker container

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,6 +17,8 @@ class ImportFormatType(str, Enum):
     bofa_bank = "bofa_bank"   # BofA Checking (Date,Description,Amount,Running Bal.)
     bofa_cc = "bofa_cc"       # BofA Credit Card (Posted Date,Reference Number,Payee,Address,Amount)
     amex_cc = "amex_cc"       # Amex Credit Card (Date,Description,Amount,Card Member,Account #)
+    inspira_hsa = "inspira_hsa"  # Inspira HSA (Transaction ID,Transaction Type,Origination Date,...)
+    venmo = "venmo"           # Venmo (ID,Datetime,Type,Status,Note,From,To,Amount...)
     unknown = "unknown"
 
 class BaseModel(SQLModel):

--- a/backend/tests/test_csv_import.py
+++ b/backend/tests/test_csv_import.py
@@ -1,10 +1,487 @@
 """
 Tests for FR-001: CSV Import
+Comprehensive tests for all CSV import formats:
+- BofA Bank (checking/savings)
+- BofA Credit Card
+- Amex Credit Card
+- Inspira HSA
+- Venmo
 """
 import pytest
 from httpx import AsyncClient
+from datetime import date
 import io
 
+from app.csv_parser import (
+    detect_format,
+    parse_csv,
+    parse_bofa_csv,
+    parse_bofa_cc_csv,
+    parse_amex_csv,
+    parse_inspira_hsa_csv,
+    parse_venmo_csv,
+    extract_merchant_from_description,
+    map_amex_category,
+)
+from app.models import ImportFormatType
+
+
+# =============================================================================
+# Unit Tests for CSV Parser Functions
+# =============================================================================
+
+class TestFormatDetection:
+    """Test format auto-detection for all supported formats"""
+
+    def test_detect_bofa_bank_format(self):
+        """Detect BofA bank format by Running Bal. column"""
+        csv_content = """Summary Bal.,$1234.56
+Some header line
+
+Date,Description,Amount,Running Bal.
+11/15/2025,PAYROLL DEPOSIT,3500.00,4734.56
+"""
+        assert detect_format(csv_content) == ImportFormatType.bofa_bank
+
+    def test_detect_bofa_cc_format(self):
+        """Detect BofA CC format by Posted Date, Reference Number, Payee"""
+        csv_content = """Posted Date,Reference Number,Payee,Address,Amount
+11/26/2025,12345678901234567890,"Coffee Shop","",-5.50
+"""
+        assert detect_format(csv_content) == ImportFormatType.bofa_cc
+
+    def test_detect_amex_format(self):
+        """Detect Amex format by Card Member and Account # columns"""
+        csv_content = """Date,Description,Card Member,Account #,Amount
+11/15/2025,AMAZON.COM,JOHN DOE,XXXXX-53004,-199.99
+"""
+        assert detect_format(csv_content) == ImportFormatType.amex_cc
+
+    def test_detect_inspira_hsa_format(self):
+        """Detect Inspira HSA format by Transaction ID, Transaction Type, Expense Category"""
+        csv_content = """"Transaction ID","Transaction Type","Origination Date","Posted Date","Description","Amount","Expense Category","Expenses for"
+"12345","Contribution","01/15/2025","01/15/2025","HSA Contribution","$500.00","","Myself"
+"""
+        assert detect_format(csv_content) == ImportFormatType.inspira_hsa
+
+    def test_detect_venmo_format_by_header(self):
+        """Detect Venmo format by Account Statement header"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip)
+"""
+        assert detect_format(csv_content) == ImportFormatType.venmo
+
+    def test_detect_venmo_format_by_columns(self):
+        """Detect Venmo format by ID, Datetime, From, To columns"""
+        csv_content = """,ID,Datetime,Type,Status,Note,From,To,Amount (total)
+,1234567890,2025-09-05T04:06:46,Payment,Complete,Test payment,John Doe,Jane Smith,- $35.00
+"""
+        assert detect_format(csv_content) == ImportFormatType.venmo
+
+    def test_detect_unknown_format(self):
+        """Unknown format for unrecognized CSV structure"""
+        csv_content = """Column1,Column2,Column3
+value1,value2,value3
+"""
+        assert detect_format(csv_content) == ImportFormatType.unknown
+
+
+class TestBofaBankParser:
+    """Test BofA bank (checking/savings) CSV parsing"""
+
+    def test_parse_basic_transactions(self):
+        """Parse standard BofA bank transactions"""
+        csv_content = """Summary Bal.,$1234.56
+Some header
+
+Date,Description,Amount,Running Bal.
+11/15/2025,PAYROLL DEPOSIT,3500.00,4734.56
+11/10/2025,AMAZON PURCHASE,-199.99,1234.56
+11/05/2025,ATM WITHDRAWAL,-200.00,1434.55
+"""
+        transactions = parse_bofa_csv(csv_content, "BOFA-Checking")
+
+        assert len(transactions) == 3
+        assert transactions[0]["amount"] == 3500.00
+        assert transactions[0]["date"] == date(2025, 11, 15)
+        assert transactions[0]["account_source"] == "BOFA-Checking"
+        assert transactions[1]["amount"] == -199.99
+        assert transactions[2]["amount"] == -200.00
+
+    def test_parse_with_commas_in_amounts(self):
+        """Handle amounts with commas (e.g., 1,234.56)"""
+        csv_content = """Date,Description,Amount,Running Bal.
+11/15/2025,LARGE DEPOSIT,"10,000.00","11,234.56"
+11/10/2025,BIG PURCHASE,"-1,500.00","1,234.56"
+"""
+        transactions = parse_bofa_csv(csv_content, "BOFA-Savings")
+
+        assert len(transactions) == 2
+        assert transactions[0]["amount"] == 10000.00
+        assert transactions[1]["amount"] == -1500.00
+
+    def test_skip_summary_rows(self):
+        """Skip balance summary rows"""
+        csv_content = """Date,Description,Amount,Running Bal.
+Beginning balance on 11/01/2025,,,1000.00
+11/15/2025,DEPOSIT,500.00,1500.00
+Ending balance on 11/30/2025,,,1500.00
+"""
+        transactions = parse_bofa_csv(csv_content, "BOFA-Test")
+
+        assert len(transactions) == 1
+        assert transactions[0]["amount"] == 500.00
+
+    def test_merchant_extraction(self):
+        """Extract merchant from BofA descriptions"""
+        csv_content = """Date,Description,Amount,Running Bal.
+11/15/2025,VENMO DES:PAYMENT ID:XXXXX78391 INDN:JOHN DOE CO,-50.00,950.00
+11/10/2025,HAEMONETICS DES:PAYROLL ID:XXXXX9028 INDN:DOE JOHN,3500.00,1000.00
+11/05/2025,T-MOBILE DES:PCS SVC ID:6527371,-85.00,1050.00
+"""
+        transactions = parse_bofa_csv(csv_content, "BOFA-Checking")
+
+        assert transactions[0]["merchant"] == "VENMO"
+        assert transactions[1]["merchant"] == "HAEMONETICS"
+        assert transactions[2]["merchant"] == "T-MOBILE"
+
+
+class TestBofaCCParser:
+    """Test BofA Credit Card CSV parsing"""
+
+    def test_parse_basic_transactions(self):
+        """Parse standard BofA CC transactions"""
+        csv_content = """Posted Date,Reference Number,Payee,Address,Amount
+11/26/2025,74863985329012411622105,"Coffee Shop Downtown","123 Main St",-5.50
+11/25/2025,24138935328002638002967,"Gas Station","456 Oak Ave",-45.00
+11/21/2025,32583204320112100065939,"PAYMENT - THANK YOU","",3846.96
+"""
+        transactions = parse_bofa_cc_csv(csv_content, "BOFA-CC-1234")
+
+        assert len(transactions) == 3
+        assert transactions[0]["amount"] == -5.50
+        assert transactions[0]["merchant"] == "Coffee Shop Downtown"
+        assert transactions[1]["amount"] == -45.00
+        assert transactions[2]["amount"] == 3846.96  # Payment is positive
+
+    def test_reference_number_used_as_id(self):
+        """Use reference number as transaction ID"""
+        csv_content = """Posted Date,Reference Number,Payee,Address,Amount
+11/26/2025,12345678901234567890,"Test Store","",-25.00
+"""
+        transactions = parse_bofa_cc_csv(csv_content, "BOFA-CC")
+
+        assert transactions[0]["reference_id"] == "12345678901234567890"
+
+    def test_payee_with_comma_in_name(self):
+        """Handle payees with commas in the name"""
+        csv_content = """Posted Date,Reference Number,Payee,Address,Amount
+11/26/2025,12345678901234567890,"Restaurant Name, Location","123 St",-85.78
+"""
+        transactions = parse_bofa_cc_csv(csv_content, "BOFA-CC")
+
+        assert transactions[0]["merchant"] == "Restaurant Name"
+        assert transactions[0]["description"] == "Restaurant Name, Location"
+
+
+class TestAmexParser:
+    """Test Amex Credit Card CSV parsing"""
+
+    def test_parse_basic_transactions(self):
+        """Parse standard Amex transactions"""
+        csv_content = """Date,Description,Card Member,Account #,Amount,Extended Details,Appears On Your Statement As,Address,City/State,Zip Code,Country,Reference,Category
+11/15/2025,AMAZON.COM,JOHN DOE,XXXXX-53004,199.99,,,,,,,320251150001,Merchandise
+11/10/2025,STARBUCKS,JOHN DOE,XXXXX-53004,12.50,,,,,,,320251100001,Restaurant-Dining
+"""
+        transactions = parse_amex_csv(csv_content)
+
+        assert len(transactions) == 2
+        # Amex amounts are flipped: positive in CSV becomes negative (expense)
+        assert transactions[0]["amount"] == -199.99
+        assert transactions[1]["amount"] == -12.50
+        assert transactions[0]["card_member"] == "JOHN DOE"
+        assert transactions[0]["account_source"] == "AMEXXXXXX-53004"
+
+    def test_skip_payment_rows(self):
+        """Skip AUTOPAY PAYMENT and THANK YOU rows"""
+        csv_content = """Date,Description,Card Member,Account #,Amount,Extended Details,Appears On Your Statement As,Address,City/State,Zip Code,Country,Reference,Category
+11/15/2025,AUTOPAY PAYMENT - THANK YOU,JOHN DOE,XXXXX-53004,-500.00,,,,,,,320251150001,
+11/10/2025,STARBUCKS,JOHN DOE,XXXXX-53004,12.50,,,,,,,320251100001,Restaurant
+"""
+        transactions = parse_amex_csv(csv_content)
+
+        assert len(transactions) == 1
+        assert transactions[0]["description"] == "STARBUCKS"
+
+    def test_category_mapping(self):
+        """Map Amex categories to simplified categories"""
+        csv_content = """Date,Description,Card Member,Account #,Amount,Extended Details,Appears On Your Statement As,Address,City/State,Zip Code,Country,Reference,Category
+11/15/2025,WHOLE FOODS,JOHN DOE,XXXXX-53004,85.00,,,,,,,320251150001,Merchandise & Supplies-Groceries
+11/10/2025,OLIVE GARDEN,JOHN DOE,XXXXX-53004,45.00,,,,,,,320251100001,Restaurant-Bar & Café
+"""
+        transactions = parse_amex_csv(csv_content)
+
+        # Category mapping happens via suggested_category
+        assert transactions[0].get("suggested_category") == "Shopping"
+        assert transactions[1].get("suggested_category") == "Dining & Coffee"
+
+    def test_merchant_extraction_from_description(self):
+        """Extract merchant from Amex multi-space descriptions"""
+        merchant = extract_merchant_from_description(
+            "TARGET              ENCINITAS           CA",
+            ImportFormatType.amex_cc
+        )
+        assert merchant == "TARGET"
+
+        merchant2 = extract_merchant_from_description(
+            "AplPay STARBUCKS    800-782-7282        WA",
+            ImportFormatType.amex_cc
+        )
+        assert merchant2 == "AplPay STARBUCKS"
+
+
+class TestInspiraHSAParser:
+    """Test Inspira HSA CSV parsing"""
+
+    def test_parse_basic_transactions(self):
+        """Parse standard Inspira HSA transactions"""
+        csv_content = """"Transaction ID","Transaction Type","Origination Date","Posted Date","Description","Amount","Expense Category","Expenses for","Contribution year","Document attached","Trade Details","Investment rebalance","Is Investment Trans Type","Verification Status"
+"12345","Contribution","01/15/2025","01/15/2025","Employer HSA Contribution","$500.00","","Myself","2025","","","","",""
+"12346","Debit Card","01/20/2025","01/20/2025","CVS PHARMACY","($29.44)","Medical","Myself","","","","","",""
+"""
+        transactions = parse_inspira_hsa_csv(csv_content, "Inspira-HSA")
+
+        assert len(transactions) == 2
+        assert transactions[0]["amount"] == 500.00
+        assert transactions[0]["date"] == date(2025, 1, 15)
+        assert transactions[1]["amount"] == -29.44
+        assert transactions[1]["date"] == date(2025, 1, 20)
+
+    def test_amount_parsing_with_parentheses(self):
+        """Parse amounts with parentheses for negatives"""
+        csv_content = """"Transaction ID","Transaction Type","Origination Date","Posted Date","Description","Amount","Expense Category","Expenses for","Contribution year","Document attached","Trade Details","Investment rebalance","Is Investment Trans Type","Verification Status"
+"001","Debit","01/01/2025","01/01/2025","PHARMACY","($100.50)","Medical","","","","","","",""
+"002","Credit","01/02/2025","01/02/2025","REFUND","$25.00","","","","","","","",""
+"003","Debit","01/03/2025","01/03/2025","DOCTOR OFFICE","($1,234.56)","Medical","","","","","","",""
+"""
+        transactions = parse_inspira_hsa_csv(csv_content, "Inspira-HSA")
+
+        assert transactions[0]["amount"] == -100.50
+        assert transactions[1]["amount"] == 25.00
+        assert transactions[2]["amount"] == -1234.56
+
+    def test_medical_category_suggestion(self):
+        """Suggest Healthcare category for Medical expense category"""
+        csv_content = """"Transaction ID","Transaction Type","Origination Date","Posted Date","Description","Amount","Expense Category","Expenses for","Contribution year","Document attached","Trade Details","Investment rebalance","Is Investment Trans Type","Verification Status"
+"001","Debit","01/01/2025","01/01/2025","PHARMACY","($50.00)","Medical","","","","","","",""
+"""
+        transactions = parse_inspira_hsa_csv(csv_content, "Inspira-HSA")
+
+        assert transactions[0]["suggested_category"] == "Healthcare"
+
+    def test_transaction_id_used_as_reference(self):
+        """Use Transaction ID as reference_id"""
+        csv_content = """"Transaction ID","Transaction Type","Origination Date","Posted Date","Description","Amount","Expense Category","Expenses for","Contribution year","Document attached","Trade Details","Investment rebalance","Is Investment Trans Type","Verification Status"
+"HSA-2025-001","Contribution","01/15/2025","01/15/2025","Contribution","$100.00","","","","","","","",""
+"""
+        transactions = parse_inspira_hsa_csv(csv_content, "Inspira-HSA")
+
+        assert transactions[0]["reference_id"] == "HSA-2025-001"
+
+
+class TestVenmoParser:
+    """Test Venmo CSV parsing"""
+
+    def test_parse_basic_transactions(self):
+        """Parse standard Venmo transactions"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip),Amount (tax),Amount (fee),Tax Rate,Tax Exempt,Funding Source,Destination,Beginning Balance,Ending Balance,Statement Period Venmo Fees,Terminal Location,Year to Date Venmo Fees,Disclaimer
+,,,,,,,,,,,,,,,,$0.00,,,,,
+,4414733187055562320,2025-09-05T04:06:46,Payment,Complete,Test payment note,John Doe,Jane Smith,- $35.00,,0,,0,,"BANK OF AMERICA, N.A. Personal Checking *1234",,,,,Venmo,,
+,4414733955578223988,2025-09-05T04:08:18,Payment,Complete,Another payment,Jane Smith,John Doe,+ $50.00,,0,,0,,,Venmo balance,,,,Venmo,,
+"""
+        transactions = parse_venmo_csv(csv_content, "Venmo")
+
+        assert len(transactions) == 2
+        assert transactions[0]["amount"] == -35.00  # Sent money
+        assert transactions[0]["merchant"] == "Jane Smith"  # Recipient
+        assert transactions[1]["amount"] == 50.00  # Received money
+        assert transactions[1]["merchant"] == "Jane Smith"  # Sender
+
+    def test_skip_incomplete_transactions(self):
+        """Skip transactions with non-Complete status"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip)
+,1234567890,2025-09-05T04:06:46,Payment,Complete,Completed payment,John Doe,Jane Smith,- $35.00,
+,1234567891,2025-09-05T04:08:18,Payment,Pending,Pending payment,John Doe,Jane Smith,- $25.00,
+,1234567892,2025-09-05T04:10:00,Payment,Failed,Failed payment,John Doe,Jane Smith,- $15.00,
+"""
+        transactions = parse_venmo_csv(csv_content, "Venmo")
+
+        assert len(transactions) == 1
+        assert transactions[0]["amount"] == -35.00
+
+    def test_skip_balance_rows(self):
+        """Skip rows without transaction ID"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip)
+,,,,,,,,,,,,,,,,$0.00,,,,,
+,1234567890,2025-09-05T04:06:46,Payment,Complete,Test,John Doe,Jane Smith,- $35.00,
+,,,,,,,,,,,,,,,,,$100.00,$0.00,,
+"""
+        transactions = parse_venmo_csv(csv_content, "Venmo")
+
+        assert len(transactions) == 1
+
+    def test_parse_charge_type_transactions(self):
+        """Parse Charge type transactions (requests for payment)"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip)
+,4414733955578223988,2025-09-05T04:08:18,Charge,Complete,Invoice for services,Jane Smith,John Doe,- $30.00,
+"""
+        transactions = parse_venmo_csv(csv_content, "Venmo")
+
+        assert len(transactions) == 1
+        assert transactions[0]["amount"] == -30.00
+
+    def test_note_used_as_description(self):
+        """Use Note field as transaction description"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip)
+,1234567890,2025-09-05T04:06:46,Payment,Complete,Dinner split at Italian restaurant,John Doe,Jane Smith,- $35.00,
+"""
+        transactions = parse_venmo_csv(csv_content, "Venmo")
+
+        assert transactions[0]["description"] == "Dinner split at Italian restaurant"
+
+    def test_fallback_description_when_no_note(self):
+        """Build description from type/from/to when note is empty"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip)
+,1234567890,2025-09-05T04:06:46,Payment,Complete,,John Doe,Jane Smith,- $35.00,
+"""
+        transactions = parse_venmo_csv(csv_content, "Venmo")
+
+        assert "Payment" in transactions[0]["description"]
+        assert "John Doe" in transactions[0]["description"]
+
+    def test_iso_datetime_parsing(self):
+        """Parse ISO format datetime correctly"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip)
+,1234567890,2025-11-28T16:32:56,Payment,Complete,Test,John Doe,Jane Smith,- $35.00,
+"""
+        transactions = parse_venmo_csv(csv_content, "Venmo")
+
+        assert transactions[0]["date"] == date(2025, 11, 28)
+
+    def test_skip_standard_transfer_type(self):
+        """Parse Standard Transfer type (Venmo to bank transfers)"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip)
+,4476008609638829232,2025-11-28T17:10:06,Standard Transfer,Issued,,,,- $558.00,
+"""
+        transactions = parse_venmo_csv(csv_content, "Venmo")
+
+        # Standard Transfer with "Issued" status should be skipped (not Complete)
+        assert len(transactions) == 0
+
+
+class TestAmexCategoryMapping:
+    """Test Amex category to simplified category mapping"""
+
+    def test_restaurant_mapping(self):
+        assert map_amex_category("Restaurant-Dining") == "Dining & Coffee"
+        assert map_amex_category("Bar & Café") == "Dining & Coffee"
+
+    def test_merchandise_mapping(self):
+        assert map_amex_category("Merchandise & Supplies") == "Shopping"
+        assert map_amex_category("Retail Stores") == "Shopping"
+        assert map_amex_category("Wholesale Clubs") == "Shopping"
+
+    def test_entertainment_mapping(self):
+        assert map_amex_category("Entertainment") == "Entertainment"
+
+    def test_healthcare_mapping(self):
+        assert map_amex_category("Health Care Services") == "Healthcare"
+
+    def test_education_mapping(self):
+        assert map_amex_category("Education") == "Education"
+
+    def test_transportation_mapping(self):
+        assert map_amex_category("Government Services-Toll") == "Transportation"
+
+    def test_subscriptions_mapping(self):
+        assert map_amex_category("Computer Supplies") == "Subscriptions"
+        assert map_amex_category("Internet Services") == "Subscriptions"
+
+    def test_utilities_mapping(self):
+        assert map_amex_category("Telecommunications") == "Utilities"
+        assert map_amex_category("Communications") == "Utilities"
+
+    def test_unknown_category_returns_none(self):
+        assert map_amex_category("Random Unknown Category") is None
+
+
+class TestParseCsvIntegration:
+    """Test the main parse_csv() function with format auto-detection"""
+
+    def test_auto_detect_and_parse_bofa_bank(self):
+        """Auto-detect BofA bank and parse"""
+        csv_content = """Date,Description,Amount,Running Bal.
+11/15/2025,DEPOSIT,500.00,1500.00
+"""
+        transactions, format_type = parse_csv(csv_content, account_source="BOFA-Test")
+
+        assert format_type == ImportFormatType.bofa_bank
+        assert len(transactions) == 1
+
+    def test_auto_detect_and_parse_amex(self):
+        """Auto-detect Amex and parse"""
+        csv_content = """Date,Description,Card Member,Account #,Amount
+11/15/2025,STORE,JOHN DOE,XXXXX-53004,50.00
+"""
+        transactions, format_type = parse_csv(csv_content)
+
+        assert format_type == ImportFormatType.amex_cc
+        assert len(transactions) == 1
+
+    def test_format_hint_overrides_detection(self):
+        """Format hint overrides auto-detection"""
+        csv_content = """Date,Description,Amount,Running Bal.
+11/15/2025,DEPOSIT,500.00,1500.00
+"""
+        # Force Amex format (will fail to parse properly, but tests hint override)
+        transactions, format_type = parse_csv(
+            csv_content,
+            format_hint=ImportFormatType.amex_cc
+        )
+
+        assert format_type == ImportFormatType.amex_cc
+
+    def test_unknown_format_returns_empty(self):
+        """Unknown format returns empty transaction list"""
+        csv_content = """Random,Headers,Here
+1,2,3
+"""
+        transactions, format_type = parse_csv(csv_content)
+
+        assert format_type == ImportFormatType.unknown
+        assert len(transactions) == 0
+
+
+# =============================================================================
+# API Integration Tests for CSV Import
+# =============================================================================
 
 class TestCSVImport:
     """FR-001: CSV Import"""
@@ -183,3 +660,170 @@ Date,Description,Amount,Running Bal.
         transactions = data["transactions"]
         # Category field now contains title-cased bucket value
         assert any(txn.get("category") or txn.get("bucket") for txn in transactions)
+
+    @pytest.mark.asyncio
+    async def test_preview_inspira_hsa_csv(self, client: AsyncClient, seed_categories):
+        """FR-001.4: Import Preview - Inspira HSA format"""
+        csv_content = """"Transaction ID","Transaction Type","Origination Date","Posted Date","Description","Amount","Expense Category","Expenses for","Contribution year","Document attached","Trade Details","Investment rebalance","Is Investment Trans Type","Verification Status"
+"12345","Contribution","01/15/2025","01/15/2025","Employer HSA Contribution","$500.00","","Myself","2025","","","","",""
+"12346","Debit Card","01/20/2025","01/20/2025","CVS PHARMACY","($29.44)","Medical","Myself","","","","","",""
+"12347","Debit Card","01/25/2025","01/25/2025","WALGREENS","($15.99)","Medical","Family","","","","","",""
+"""
+
+        files = {"file": ("hsa_export.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+        data_payload = {"account_source": "Inspira-HSA"}
+
+        response = await client.post(
+            "/api/v1/import/preview",
+            files=files,
+            data=data_payload
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # FR-001.2: Format Detection
+        assert data["detected_format"] == "inspira_hsa"
+
+        # Verify transactions parsed correctly
+        assert "transactions" in data
+        assert len(data["transactions"]) == 3
+        assert data["transaction_count"] == 3
+
+        # Verify amounts (contribution positive, debits negative)
+        amounts = [t["amount"] for t in data["transactions"]]
+        assert 500.00 in amounts
+        assert -29.44 in amounts
+        assert -15.99 in amounts
+
+    @pytest.mark.asyncio
+    async def test_preview_venmo_csv(self, client: AsyncClient, seed_categories):
+        """FR-001.4: Import Preview - Venmo format"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip),Amount (tax),Amount (fee),Tax Rate,Tax Exempt,Funding Source,Destination,Beginning Balance,Ending Balance,Statement Period Venmo Fees,Terminal Location,Year to Date Venmo Fees,Disclaimer
+,,,,,,,,,,,,,,,,$0.00,,,,,
+,4414733187055562320,2025-09-05T04:06:46,Payment,Complete,Dinner split,John Doe,Jane Smith,- $35.00,,0,,0,,"BANK OF AMERICA, N.A. Personal Checking *1234",,,,,Venmo,,
+,4414733955578223988,2025-09-05T04:08:18,Payment,Complete,Rent payment,Jane Smith,John Doe,+ $500.00,,0,,0,,,Venmo balance,,,,Venmo,,
+,4414734273322117992,2025-09-05T04:08:56,Payment,Complete,Coffee run,John Doe,Bob Wilson,- $12.50,,0,,0,,"BANK OF AMERICA, N.A. Personal Checking *1234",,,,,Venmo,,
+"""
+
+        files = {"file": ("venmo_statement.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+        data_payload = {"account_source": "Venmo"}
+
+        response = await client.post(
+            "/api/v1/import/preview",
+            files=files,
+            data=data_payload
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # FR-001.2: Format Detection
+        assert data["detected_format"] == "venmo"
+
+        # Verify transactions parsed correctly
+        assert "transactions" in data
+        assert len(data["transactions"]) == 3
+        assert data["transaction_count"] == 3
+
+        # Verify amounts (sent = negative, received = positive)
+        amounts = [t["amount"] for t in data["transactions"]]
+        assert -35.00 in amounts
+        assert 500.00 in amounts
+        assert -12.50 in amounts
+
+    @pytest.mark.asyncio
+    async def test_confirm_inspira_hsa_import(self, client: AsyncClient, seed_categories):
+        """FR-001.5: Confirm import for Inspira HSA"""
+        csv_content = """"Transaction ID","Transaction Type","Origination Date","Posted Date","Description","Amount","Expense Category","Expenses for","Contribution year","Document attached","Trade Details","Investment rebalance","Is Investment Trans Type","Verification Status"
+"HSA-001","Contribution","01/15/2025","01/15/2025","Contribution","$250.00","","","","","","","",""
+"HSA-002","Debit Card","01/20/2025","01/20/2025","PHARMACY","($50.00)","Medical","","","","","","",""
+"""
+
+        files = {"file": ("hsa.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+        data_payload = {"format_type": "inspira_hsa", "account_source": "Inspira-HSA"}
+
+        response = await client.post(
+            "/api/v1/import/confirm",
+            files=files,
+            data=data_payload
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["imported"] == 2
+        assert data["duplicates"] == 0
+
+    @pytest.mark.asyncio
+    async def test_confirm_venmo_import(self, client: AsyncClient, seed_categories):
+        """FR-001.5: Confirm import for Venmo"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip),Amount (tax),Amount (fee),Tax Rate,Tax Exempt,Funding Source,Destination,Beginning Balance,Ending Balance,Statement Period Venmo Fees,Terminal Location,Year to Date Venmo Fees,Disclaimer
+,1234567890,2025-10-01T12:00:00,Payment,Complete,Test payment,John Doe,Jane Smith,- $25.00,,0,,0,,,Venmo balance,,,,Venmo,,
+,1234567891,2025-10-02T14:30:00,Payment,Complete,Refund,Jane Smith,John Doe,+ $10.00,,0,,0,,,Venmo balance,,,,Venmo,,
+"""
+
+        files = {"file": ("venmo.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+        data_payload = {"format_type": "venmo", "account_source": "Venmo"}
+
+        response = await client.post(
+            "/api/v1/import/confirm",
+            files=files,
+            data=data_payload
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["imported"] == 2
+        assert data["duplicates"] == 0
+
+    @pytest.mark.asyncio
+    async def test_venmo_duplicate_detection(self, client: AsyncClient, seed_categories):
+        """FR-001.5: Venmo duplicate detection by transaction ID"""
+        csv_content = """Account Statement - (@johndoe) ,,,,,,,,,,,,,,,,,,,,,
+Account Activity,,,,,,,,,,,,,,,,,,,,,
+,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (tip)
+,9999888877776666,2025-10-01T12:00:00,Payment,Complete,Unique transaction,John Doe,Jane Smith,- $100.00,
+"""
+
+        # First import
+        files = {"file": ("venmo.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+        data_payload = {"format_type": "venmo", "account_source": "Venmo"}
+
+        response1 = await client.post("/api/v1/import/confirm", files=files, data=data_payload)
+        assert response1.status_code == 200
+        assert response1.json()["imported"] == 1
+
+        # Second import of same transaction
+        files2 = {"file": ("venmo.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+        response2 = await client.post("/api/v1/import/confirm", files=files2, data=data_payload)
+        assert response2.status_code == 200
+        assert response2.json()["duplicates"] == 1
+        assert response2.json()["imported"] == 0
+
+    @pytest.mark.asyncio
+    async def test_inspira_duplicate_detection(self, client: AsyncClient, seed_categories):
+        """FR-001.5: Inspira HSA duplicate detection by transaction ID"""
+        csv_content = """"Transaction ID","Transaction Type","Origination Date","Posted Date","Description","Amount","Expense Category","Expenses for","Contribution year","Document attached","Trade Details","Investment rebalance","Is Investment Trans Type","Verification Status"
+"UNIQUE-HSA-99999","Contribution","01/15/2025","01/15/2025","Test","$100.00","","","","","","","",""
+"""
+
+        # First import
+        files = {"file": ("hsa.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+        data_payload = {"format_type": "inspira_hsa", "account_source": "Inspira-HSA"}
+
+        response1 = await client.post("/api/v1/import/confirm", files=files, data=data_payload)
+        assert response1.status_code == 200
+        assert response1.json()["imported"] == 1
+
+        # Second import of same transaction
+        files2 = {"file": ("hsa.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+        response2 = await client.post("/api/v1/import/confirm", files=files2, data=data_payload)
+        assert response2.status_code == 200
+        assert response2.json()["duplicates"] == 1
+        assert response2.json()["imported"] == 0

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { format } from 'date-fns'
+import Link from 'next/link'
 import { formatCurrency } from '@/lib/format'
 import { PageHelp } from '@/components/PageHelp'
 
@@ -9,6 +10,8 @@ const FORMAT_NAMES: Record<string, string> = {
   'bofa_bank': 'BofA Bank',
   'bofa_cc': 'BofA CC',
   'amex_cc': 'Amex CC',
+  'inspira_hsa': 'Inspira HSA',
+  'venmo': 'Venmo',
   'unknown': 'Unknown'
 }
 
@@ -422,11 +425,19 @@ export default function AdminPage() {
       {/* Imports Tab */}
       {activeTab === 'imports' && (
         <div className="card">
-          <div className="px-6 py-4 border-b border-theme">
-            <h2 className="text-lg font-semibold text-theme">Import Sessions</h2>
-            <p className="text-sm text-theme-muted">
-              History of all CSV imports. You can roll back individual imports by deleting their sessions.
-            </p>
+          <div className="px-6 py-4 border-b border-theme flex justify-between items-start">
+            <div>
+              <h2 className="text-lg font-semibold text-theme">Import Sessions</h2>
+              <p className="text-sm text-theme-muted">
+                History of all CSV imports. You can roll back individual imports by deleting their sessions.
+              </p>
+            </div>
+            <Link
+              href="/import"
+              className="btn-primary"
+            >
+              Import New
+            </Link>
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-[var(--color-border)]">

--- a/frontend/src/app/import/page.tsx
+++ b/frontend/src/app/import/page.tsx
@@ -9,6 +9,8 @@ const FORMAT_NAMES: Record<string, string> = {
   'bofa_bank': 'Bank of America (Checking/Savings)',
   'bofa_cc': 'Bank of America (Credit Card)',
   'amex_cc': 'American Express',
+  'inspira_hsa': 'Inspira HSA',
+  'venmo': 'Venmo',
   'unknown': 'Unknown'
 }
 
@@ -428,6 +430,8 @@ export default function ImportPage() {
               <option value="bofa_bank">Bank of America (Checking/Savings)</option>
               <option value="bofa_cc">Bank of America (Credit Card)</option>
               <option value="amex_cc">American Express</option>
+              <option value="inspira_hsa">Inspira HSA</option>
+              <option value="venmo">Venmo</option>
             </select>
           </div>
         </div>

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -91,6 +91,8 @@ function TransactionsContent() {
     startDate: '',
     endDate: ''
   })
+  // Separate state for search input to prevent refetch on every keystroke
+  const [searchInput, setSearchInput] = useState('')
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false)
   const [showAccountDropdown, setShowAccountDropdown] = useState(false)
   const [addingTagTo, setAddingTagTo] = useState<number | null>(null)
@@ -151,6 +153,7 @@ function TransactionsContent() {
       startDate,
       endDate
     })
+    setSearchInput(search) // Sync search input with URL param
     setFiltersInitialized(true)
   }, [searchParams])
 
@@ -571,9 +574,13 @@ function TransactionsContent() {
             type="text"
             placeholder="Search merchant or description..."
             className="input"
-            value={filters.search}
-            onChange={(e) => setFilters({ ...filters, search: e.target.value })}
-            onKeyDown={(e) => e.key === 'Enter' && fetchTransactions()}
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                setFilters({ ...filters, search: searchInput })
+              }
+            }}
           />
           <select
             className="input"
@@ -691,7 +698,7 @@ function TransactionsContent() {
           </div>
           <div className="flex gap-2">
             <button
-              onClick={fetchTransactions}
+              onClick={() => setFilters({ ...filters, search: searchInput })}
               className="flex-1 btn-primary"
             >
               Search
@@ -756,6 +763,7 @@ function TransactionsContent() {
               />
               <button
                 onClick={() => {
+                  setSearchInput('')
                   setFilters({
                     search: '',
                     bucket: '',


### PR DESCRIPTION
## Summary
- Add Inspira HSA and Venmo to supported CSV import formats
- Fix search input bug that reset page on each keystroke
- Add "Import New" button to admin Imports tab
- Add `make docker-build-force` for no-cache builds

## Changes
- **Backend**: New parsers for Inspira HSA and Venmo formats with auto-detection
- **Frontend**: Updated FORMAT_NAMES, fixed search debounce, added import button to admin
- **Tests**: 56 comprehensive parser tests covering all formats
- **Makefile**: Added docker-build-force target

## Test plan
- [x] All 266 unit tests pass
- [x] Docker build succeeds
- [x] Import preview works for new formats
- [x] Search input no longer resets page on keystroke