### PR TITLE
feat: complete transfer detection UI and filtering

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

### Transfer Detection
- Add `is_transfer` filter parameter to transactions list/count API endpoints
- Add transfer filter toggle in transactions page advanced filters (Hide/All/Only)
- Add transfer marking controls in expanded transaction details with toggle and unlink
- Add transfer marking to reconciliation workflow (bulk "Transfer" button + individual "T" action)

### Dashboard Month Selector
- Add prev/next month navigation arrows to dashboard header
- View any historical month's data (not just current month)
- Update top-merchants endpoint to accept year/month parameters for specific month queries

## Changes
| File | Changes |
|------|---------|
| `backend/app/routers/transactions.py` | Added `is_transfer` query parameter to filter endpoints |
| `backend/app/routers/reports.py` | Added year/month params to top-merchants endpoint |
| `frontend/src/app/page.tsx` | Month selector UI with navigation |
| `frontend/src/app/transactions/page.tsx` | Transfer filter dropdown, toggle button in expanded view, unlink UI |
| `frontend/src/app/reconcile/page.tsx` | Bulk and individual "Mark as Transfer" actions |

## Test plan
- [ ] Filter transactions with "Hide Transfers" (default) - transfers should not appear
- [ ] Filter with "All Transactions" - transfers appear with blue badge
- [ ] Filter with "Transfers Only" - only transfers shown
- [ ] Expand a transaction, click transfer toggle to mark/unmark
- [ ] For linked transfers, verify unlink button works
- [ ] On reconcile page, mark individual transaction as transfer with "T" button
- [ ] On reconcile page, select multiple and use "Transfer N" bulk action
- [ ] On dashboard, click prev arrow to navigate to previous month
- [ ] Verify dashboard data updates when changing months
- [ ] Verify all 282 backend tests pass