### PR TITLE
Refactor: Split Makefile into modular components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,25 @@
-.PHONY: help setup install install-backend install-frontend db-init db-seed db-reset backend frontend dev clean anonymize anonymize-status anonymize-force test-backend test-unit test-reports test-tags test-import test-budgets test-e2e test-e2e-install test-e2e-headed test-e2e-debug test-e2e-import test-e2e-full test-all docker-build docker-up docker-down docker-logs docker-shell docker-clean docker-seed docker-migrate release release-patch release-minor release-major
+# =============================================================================
+# Maxwell's Wallet - Makefile
+# =============================================================================
+#
+# This is the main entry point for all make commands. Commands are organized
+# into separate files under make/ for better maintainability:
+#
+#   make/dev.mk      - Development servers (backend, frontend, dev)
+#   make/db.mk       - Database operations (init, seed, migrate)
+#   make/test.mk     - Testing (unit, e2e, lint)
+#   make/docker.mk   - Docker operations (build, up, down)
+#   make/release.mk  - Release automation (release, release-patch)
+#   make/utils.mk    - Utilities (clean, status, info)
+#
+# Run 'make help' to see all available commands.
+# =============================================================================
 
-# Default target
 .DEFAULT_GOAL := help
+
+# -----------------------------------------------------------------------------
+# Shared Variables
+# -----------------------------------------------------------------------------
 
 # Color output
 BLUE := \033[0;34m
@@ -14,11 +32,22 @@ NC := \033[0m # No Color
 BACKEND_DIR := backend
 FRONTEND_DIR := frontend
 
+# Export for use in included files
+export BLUE GREEN YELLOW RED NC BACKEND_DIR FRONTEND_DIR
+
+# -----------------------------------------------------------------------------
+# Core Targets
+# -----------------------------------------------------------------------------
+
+.PHONY: help setup install install-backend install-frontend
+
 help: ## Show this help message
 	@echo "$(BLUE)Maxwell's Wallet - Personal Finance Tracker$(NC)"
 	@echo ""
 	@echo "$(GREEN)Available targets:$(NC)"
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(YELLOW)%-20s$(NC) %s\n", $$1, $$2}'
+	@grep -hE '^[a-zA-Z0-9_-]+:.*## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  $(YELLOW)%-20s$(NC) %s\n", $$1, $$2}'
+	@echo ""
+	@echo "$(GREEN)Documentation:$(NC) See docs/MAKEFILE.md for detailed usage"
 	@echo ""
 
 setup: ## First-time setup (install dependencies + seed database)
@@ -45,325 +74,13 @@ install-frontend: ## Install frontend dependencies
 	@cd $(FRONTEND_DIR) && npm install baseline-browser-mapping@latest -D 2>/dev/null || true
 	@echo "$(GREEN)✓ Frontend dependencies installed$(NC)"
 
-db-init: ## Initialize database (create tables)
-	@echo "$(BLUE)Initializing database...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		. .venv/bin/activate && \
-		uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"
-	@echo "$(GREEN)✓ Database initialized$(NC)"
+# -----------------------------------------------------------------------------
+# Include Modular Makefiles
+# -----------------------------------------------------------------------------
 
-db-seed: ## Seed database with sample data and default categories
-	@echo "$(BLUE)Seeding database...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		. .venv/bin/activate && \
-		uv run python -m app.seed
-	@echo "$(GREEN)✓ Database seeded$(NC)"
-
-db-reset: ## Reset database (delete and recreate)
-	@echo "$(RED)Resetting database...$(NC)"
-	@rm -f $(BACKEND_DIR)/wallet.db
-	@$(MAKE) db-init
-	@$(MAKE) db-seed
-	@echo "$(GREEN)✓ Database reset complete$(NC)"
-
-db-migrate: ## Create new database migration
-	@echo "$(BLUE)Creating database migration...$(NC)"
-	@read -p "Migration message: " msg; \
-	cd $(BACKEND_DIR) && \
-		. .venv/bin/activate && \
-		uv run alembic revision --autogenerate -m "$$msg"
-	@echo "$(GREEN)✓ Migration created$(NC)"
-
-db-upgrade: ## Apply database migrations
-	@echo "$(BLUE)Applying database migrations...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		. .venv/bin/activate && \
-		uv run alembic upgrade head
-	@echo "$(GREEN)✓ Migrations applied$(NC)"
-
-backend: ## Run backend server
-	@echo "$(BLUE)Starting backend server...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		. .venv/bin/activate && \
-		uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
-
-frontend: ## Run frontend development server
-	@echo "$(BLUE)Starting frontend server...$(NC)"
-	@cd $(FRONTEND_DIR) && npm run dev
-
-dev: ## Run both backend and frontend (in parallel)
-	@echo "$(BLUE)Starting development servers...$(NC)"
-	@$(MAKE) -j2 backend frontend
-
-build-frontend: ## Build frontend for production
-	@echo "$(BLUE)Building frontend...$(NC)"
-	@cd $(FRONTEND_DIR) && npm run build
-	@echo "$(GREEN)✓ Frontend built$(NC)"
-
-test-backend: ## Run backend tests
-	@echo "$(BLUE)Running backend tests...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		.venv/bin/python -m pytest --ignore=tests/e2e -v
-	@echo "$(GREEN)✓ Tests complete$(NC)"
-
-test-unit: test-backend ## Run unit/integration tests (alias)
-
-test-reports: ## Run report/analytics tests only
-	@echo "$(BLUE)Running report tests...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		.venv/bin/python -m pytest tests/test_reports.py tests/test_new_analytics.py -v
-	@echo "$(GREEN)✓ Report tests complete$(NC)"
-
-test-tags: ## Run tag system tests only
-	@echo "$(BLUE)Running tag system tests...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		.venv/bin/python -m pytest tests/test_tags.py tests/test_tag_rules.py -v
-	@echo "$(GREEN)✓ Tag system tests complete$(NC)"
-
-test-import: ## Run CSV import tests only
-	@echo "$(BLUE)Running import tests...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		.venv/bin/python -m pytest tests/test_csv_import.py -v
-	@echo "$(GREEN)✓ Import tests complete$(NC)"
-
-test-budgets: ## Run budget tests only
-	@echo "$(BLUE)Running budget tests...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		.venv/bin/python -m pytest tests/test_budgets.py -v
-	@echo "$(GREEN)✓ Budget tests complete$(NC)"
-
-# =============================================================================
-# End-to-End Tests (Playwright)
-# =============================================================================
-
-test-e2e-install: ## Install Playwright browsers for E2E tests
-	@echo "$(BLUE)Installing Playwright browsers...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		. .venv/bin/activate && \
-		uv pip install pytest-playwright playwright && \
-		playwright install chromium
-	@echo "$(GREEN)✓ Playwright browsers installed$(NC)"
-
-test-e2e: ## Run E2E validation tests (requires 'make dev' running in another terminal)
-	@echo "$(BLUE)Running E2E validation tests...$(NC)"
-	@echo "$(YELLOW)Checking if servers are running...$(NC)"
-	@curl -s http://localhost:8000/api/v1/transactions >/dev/null 2>&1 || { echo "$(RED)Backend not running. Start with: make dev$(NC)"; exit 1; }
-	@curl -s http://localhost:3000 >/dev/null 2>&1 || { echo "$(RED)Frontend not running. Start with: make dev$(NC)"; exit 1; }
-	@echo "$(GREEN)Servers detected, running tests...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		.venv/bin/python -m pytest tests/e2e -v --tb=short
-	@echo "$(GREEN)✓ E2E tests complete$(NC)"
-
-test-e2e-headed: ## Run E2E tests with visible browser
-	@echo "$(BLUE)Running E2E tests (headed mode)...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		.venv/bin/python -m pytest tests/e2e -v --headed --tb=short
-	@echo "$(GREEN)✓ E2E tests complete$(NC)"
-
-test-e2e-debug: ## Run E2E tests in debug mode (slow, with browser visible)
-	@echo "$(BLUE)Running E2E tests in debug mode...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		PWDEBUG=1 .venv/bin/python -m pytest tests/e2e -v -s --headed
-	@echo "$(GREEN)✓ E2E debug session complete$(NC)"
-
-test-e2e-import: ## Run only import workflow E2E tests
-	@echo "$(BLUE)Running import workflow E2E tests...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		.venv/bin/python -m pytest tests/e2e/test_import_workflow.py -v
-	@echo "$(GREEN)✓ Import E2E tests complete$(NC)"
-
-test-e2e-full: ## Run full workflow E2E tests (slow)
-	@echo "$(BLUE)Running full workflow E2E tests...$(NC)"
-	@cd $(BACKEND_DIR) && \
-		unset VIRTUAL_ENV && \
-		.venv/bin/python -m pytest tests/e2e/test_full_workflow.py -v --tb=short
-	@echo "$(GREEN)✓ Full workflow E2E tests complete$(NC)"
-
-test-all: test-backend test-e2e ## Run all tests (unit + E2E)
-
-lint-frontend: ## Lint frontend code
-	@echo "$(BLUE)Linting frontend...$(NC)"
-	@cd $(FRONTEND_DIR) && npm run lint
-	@echo "$(GREEN)✓ Linting complete$(NC)"
-
-# =============================================================================
-# Test Data Anonymization
-# =============================================================================
-
-anonymize: ## Anonymize CSV files in data/raw/ -> data/anonymized/
-	@echo "$(BLUE)Anonymizing test data...$(NC)"
-	@cd $(BACKEND_DIR) && . .venv/bin/activate && python ../scripts/anonymize_import.py
-	@echo "$(GREEN)✓ Anonymization complete$(NC)"
-
-anonymize-status: ## Show status of anonymized test data
-	@cd $(BACKEND_DIR) && . .venv/bin/activate && python ../scripts/anonymize_import.py --status
-
-anonymize-force: ## Force re-anonymize all test data files
-	@echo "$(BLUE)Force re-anonymizing all test data...$(NC)"
-	@cd $(BACKEND_DIR) && . .venv/bin/activate && python ../scripts/anonymize_import.py --force
-	@echo "$(GREEN)✓ Anonymization complete$(NC)"
-
-clean: ## Clean build artifacts and caches
-	@echo "$(BLUE)Cleaning build artifacts...$(NC)"
-	@rm -rf $(BACKEND_DIR)/__pycache__
-	@rm -rf $(BACKEND_DIR)/.pytest_cache
-	@rm -rf $(BACKEND_DIR)/app/__pycache__
-	@rm -rf $(BACKEND_DIR)/app/routers/__pycache__
-	@rm -rf $(FRONTEND_DIR)/.next
-	@rm -rf $(FRONTEND_DIR)/out
-	@rm -rf $(FRONTEND_DIR)/node_modules/.cache
-	@echo "$(GREEN)✓ Cleaned$(NC)"
-
-clean-all: clean ## Clean everything including dependencies and database
-	@echo "$(RED)Cleaning all dependencies and database...$(NC)"
-	@rm -rf $(BACKEND_DIR)/.venv
-	@rm -rf $(FRONTEND_DIR)/node_modules
-	@rm -f $(BACKEND_DIR)/wallet.db
-	@echo "$(GREEN)✓ All cleaned$(NC)"
-
-status: ## Check status of services
-	@echo "$(BLUE)Service Status:$(NC)"
-	@echo ""
-	@echo "Backend:"
-	@curl -s http://localhost:8000/health 2>/dev/null && echo "$(GREEN)  ✓ Running at http://localhost:8000$(NC)" || echo "$(RED)  ✗ Not running$(NC)"
-	@echo ""
-	@echo "Frontend:"
-	@curl -s http://localhost:3000 >/dev/null 2>&1 && echo "$(GREEN)  ✓ Running at http://localhost:3000$(NC)" || echo "$(RED)  ✗ Not running$(NC)"
-	@echo ""
-
-info: ## Show project information
-	@echo "$(BLUE)Maxwell's Wallet - Personal Finance Tracker$(NC)"
-	@echo ""
-	@echo "Project: maxwells-wallet"
-	@echo "Backend:  FastAPI + Python + SQLModel"
-	@echo "Frontend: Next.js + TypeScript + Tailwind CSS"
-	@echo ""
-	@echo "$(GREEN)Features:$(NC)"
-	@echo "  • CSV import (BOFA, AMEX)"
-	@echo "  • Smart categorization"
-	@echo "  • Monthly spending analysis"
-	@echo "  • Transaction reconciliation"
-	@echo ""
-	@echo "$(YELLOW)Quick Start:$(NC)"
-	@echo "  1. make setup      # First-time setup"
-	@echo "  2. make dev        # Start development servers"
-	@echo "  3. Open http://localhost:3000"
-	@echo ""
-
-.PHONY: check-deps
-check-deps: ## Check if required dependencies are installed
-	@echo "$(BLUE)Checking dependencies...$(NC)"
-	@command -v python3 >/dev/null 2>&1 || { echo "$(RED)✗ Python 3 not found$(NC)"; exit 1; }
-	@command -v uv >/dev/null 2>&1 || { echo "$(RED)✗ uv not found. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh$(NC)"; exit 1; }
-	@command -v node >/dev/null 2>&1 || { echo "$(RED)✗ Node.js not found$(NC)"; exit 1; }
-	@command -v npm >/dev/null 2>&1 || { echo "$(RED)✗ npm not found. Install Node.js from nodejs.org$(NC)"; exit 1; }
-	@echo "$(GREEN)✓ All dependencies found$(NC)"
-
-# =============================================================================
-# Docker targets
-# =============================================================================
-
-.PHONY: docker-build docker-build-force docker-up docker-down docker-logs docker-shell
-
-docker-build: ## Build Docker image
-	@echo "$(BLUE)Building Docker image...$(NC)"
-	docker compose build
-	@echo "$(GREEN)✓ Docker image built$(NC)"
-
-docker-build-force: ## Build Docker image (no cache)
-	@echo "$(BLUE)Building Docker image (no cache)...$(NC)"
-	docker compose build --no-cache
-	@echo "$(GREEN)✓ Docker image built$(NC)"
-
-docker-up: ## Start Docker container
-	@echo "$(BLUE)Starting Docker container...$(NC)"
-	docker compose up -d
-	@echo "$(GREEN)✓ Container started$(NC)"
-	@echo ""
-	@echo "Frontend: http://localhost:3000"
-	@echo "Backend:  http://localhost:8000"
-
-docker-down: ## Stop Docker container
-	@echo "$(BLUE)Stopping Docker container...$(NC)"
-	docker compose down
-	@echo "$(GREEN)✓ Container stopped$(NC)"
-
-docker-logs: ## View Docker logs
-	docker compose logs -f
-
-docker-shell: ## Open shell in Docker container
-	docker compose exec maxwells-wallet /bin/bash
-
-docker-clean: ## Remove Docker containers and volumes
-	@echo "$(RED)Removing Docker containers and volumes...$(NC)"
-	docker compose down -v
-	@echo "$(GREEN)✓ Cleaned$(NC)"
-
-docker-seed: ## Seed database with sample data
-	@echo "$(BLUE)Seeding database...$(NC)"
-	docker compose run --rm maxwells-wallet seed
-	@echo "$(GREEN)✓ Database seeded$(NC)"
-
-docker-migrate: ## Run database migrations
-	@echo "$(BLUE)Running migrations...$(NC)"
-	docker compose run --rm maxwells-wallet migrate
-	@echo "$(GREEN)✓ Migrations complete$(NC)"
-
-# =============================================================================
-# Release targets
-# =============================================================================
-
-# Get current version from backend/pyproject.toml
-CURRENT_VERSION := $(shell grep -E '^version = ' $(BACKEND_DIR)/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-
-release: ## Create a release (usage: make release VERSION=x.y.z)
-	@if [ -z "$(VERSION)" ]; then \
-		echo "\033[0;34mRelease Commands:\033[0m"; \
-		echo ""; \
-		echo "  \033[0;33mmake release VERSION=x.y.z\033[0m  - Release specific version"; \
-		echo "  \033[0;33mmake release-patch\033[0m          - $(CURRENT_VERSION) -> next patch"; \
-		echo "  \033[0;33mmake release-minor\033[0m          - $(CURRENT_VERSION) -> next minor"; \
-		echo "  \033[0;33mmake release-major\033[0m          - $(CURRENT_VERSION) -> next major"; \
-		echo ""; \
-		echo "Current version: \033[0;32m$(CURRENT_VERSION)\033[0m"; \
-	else \
-		echo "\033[0;34mCreating release v$(VERSION)...\033[0m"; \
-		sed -i '' 's/^version = ".*"/version = "$(VERSION)"/' $(BACKEND_DIR)/pyproject.toml; \
-		sed -i '' 's/"version": ".*"/"version": "$(VERSION)"/' $(FRONTEND_DIR)/package.json; \
-		./scripts/generate-changelog.sh $(VERSION); \
-		git add -A; \
-		git commit -m "chore: release v$(VERSION)"; \
-		git tag v$(VERSION); \
-		echo "\033[0;34mPushing to GitHub...\033[0m"; \
-		git push origin main --tags; \
-		echo ""; \
-		echo "\033[0;32m✓ Release v$(VERSION) created!\033[0m"; \
-		echo ""; \
-		echo "GitHub Actions will now:"; \
-		echo "  1. Create GitHub Release with changelog"; \
-		echo "  2. Build Docker image"; \
-		echo "  3. Push to ghcr.io/poindexter12/maxwells-wallet:$(VERSION)"; \
-		echo ""; \
-		echo "Monitor progress: \033[0;33mgh run watch\033[0m"; \
-	fi
-
-release-patch: ## Create a patch release (x.y.Z+1)
-	@NEW_VERSION=$$(echo $(CURRENT_VERSION) | awk -F. '{print $$1"."$$2"."$$3+1}'); \
-	$(MAKE) release VERSION=$$NEW_VERSION
-
-release-minor: ## Create a minor release (x.Y+1.0)
-	@NEW_VERSION=$$(echo $(CURRENT_VERSION) | awk -F. '{print $$1"."$$2+1".0"}'); \
-	$(MAKE) release VERSION=$$NEW_VERSION
-
-release-major: ## Create a major release (X+1.0.0)
-	@NEW_VERSION=$$(echo $(CURRENT_VERSION) | awk -F. '{print $$1+1".0.0"}'); \
-	$(MAKE) release VERSION=$$NEW_VERSION
+include make/dev.mk
+include make/db.mk
+include make/test.mk
+include make/docker.mk
+include make/release.mk
+include make/utils.mk

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -1,0 +1,223 @@
+# Makefile Commands
+
+This document provides detailed information about all available `make` commands for Maxwell's Wallet.
+
+Run `make` or `make help` to see a quick reference of all commands.
+
+## Quick Start
+
+```bash
+make setup   # First-time setup (installs deps, inits DB, seeds data)
+make dev     # Start both backend and frontend servers
+```
+
+## File Organization
+
+Commands are organized into modular files under `make/`:
+
+| File | Purpose |
+|------|---------|
+| `Makefile` | Main entry point, shared variables, core targets |
+| `make/dev.mk` | Development servers |
+| `make/db.mk` | Database operations |
+| `make/test.mk` | Testing (unit, e2e, lint) |
+| `make/docker.mk` | Docker operations |
+| `make/release.mk` | Release automation |
+| `make/utils.mk` | Utilities (clean, status, info) |
+
+---
+
+## Core Commands
+
+### `make setup`
+First-time setup. Runs `install`, `db-init`, and `db-seed`.
+
+### `make install`
+Install all dependencies (backend + frontend).
+
+### `make install-backend`
+Install Python dependencies using `uv`.
+
+### `make install-frontend`
+Install Node.js dependencies using `npm`.
+
+---
+
+## Development
+
+### `make dev`
+Start both backend and frontend servers in parallel.
+- Backend: http://localhost:8000
+- Frontend: http://localhost:3000
+
+### `make backend`
+Start only the backend FastAPI server with hot reload.
+
+### `make frontend`
+Start only the frontend Next.js development server.
+
+### `make build-frontend`
+Build the frontend for production.
+
+---
+
+## Database
+
+### `make db-init`
+Initialize the database by creating all tables.
+
+### `make db-seed`
+Seed the database with sample data and default categories.
+
+### `make db-reset`
+Delete and recreate the database (runs `db-init` + `db-seed`).
+
+### `make db-migrate`
+Create a new Alembic migration. Prompts for a migration message.
+
+### `make db-upgrade`
+Apply all pending database migrations.
+
+---
+
+## Testing
+
+### Unit & Integration Tests
+
+```bash
+make test-backend    # Run all backend tests (excludes E2E)
+make test-unit       # Alias for test-backend
+make test-reports    # Run report/analytics tests only
+make test-tags       # Run tag system tests only
+make test-import     # Run CSV import tests only
+make test-budgets    # Run budget tests only
+make test-all        # Run all tests (unit + E2E)
+```
+
+### End-to-End Tests (Playwright)
+
+**Prerequisite:** Run `make dev` in another terminal first.
+
+```bash
+make test-e2e-install   # Install Playwright browsers (one-time setup)
+make test-e2e           # Run E2E tests (headless)
+make test-e2e-headed    # Run E2E tests with visible browser
+make test-e2e-debug     # Run E2E tests in debug mode (slow, step-through)
+make test-e2e-import    # Run only import workflow tests
+make test-e2e-full      # Run full workflow tests (slow)
+```
+
+### Linting
+
+```bash
+make lint-frontend   # Lint frontend code with ESLint
+```
+
+---
+
+## Docker
+
+### Building
+
+```bash
+make docker-build        # Build Docker image
+make docker-build-force  # Build Docker image without cache
+```
+
+### Running
+
+```bash
+make docker-up      # Start container (detached)
+make docker-down    # Stop container
+make docker-logs    # View container logs (follow mode)
+make docker-shell   # Open bash shell in running container
+```
+
+### Database in Docker
+
+```bash
+make docker-seed     # Seed database with sample data
+make docker-migrate  # Run database migrations
+```
+
+### Cleanup
+
+```bash
+make docker-clean   # Remove containers and volumes
+```
+
+---
+
+## Release
+
+Automated release workflow that updates versions, generates changelog, commits, tags, and pushes to trigger GitHub Actions.
+
+```bash
+make release                  # Show usage
+make release VERSION=1.2.3    # Release specific version
+make release-patch            # Bump patch version (0.4.4 -> 0.4.5)
+make release-minor            # Bump minor version (0.4.4 -> 0.5.0)
+make release-major            # Bump major version (0.4.4 -> 1.0.0)
+```
+
+GitHub Actions will then:
+1. Create a GitHub Release with changelog
+2. Build Docker image
+3. Push to `ghcr.io/poindexter12/maxwells-wallet:<version>`
+
+---
+
+## Utilities
+
+### Status & Info
+
+```bash
+make status      # Check if backend/frontend servers are running
+make info        # Show project information and features
+make check-deps  # Verify required dependencies are installed
+```
+
+### Cleaning
+
+```bash
+make clean       # Clean build artifacts and caches
+make clean-all   # Clean everything (including .venv, node_modules, DB)
+```
+
+### Test Data Anonymization
+
+```bash
+make anonymize         # Anonymize CSV files (data/raw/ -> data/anonymized/)
+make anonymize-status  # Show status of anonymized files
+make anonymize-force   # Force re-anonymize all files
+```
+
+---
+
+## Common Workflows
+
+### Daily Development
+```bash
+make dev   # Start servers, then work in your editor
+```
+
+### Running Tests Before Commit
+```bash
+make test-backend lint-frontend
+```
+
+### Fresh Start
+```bash
+make clean-all
+make setup
+make dev
+```
+
+### Creating a Release
+```bash
+# Ensure all tests pass
+make test-all
+
+# Create release
+make release-patch   # or release-minor, release-major
+```

--- a/make/db.mk
+++ b/make/db.mk
@@ -1,0 +1,41 @@
+# =============================================================================
+# Database Targets
+# =============================================================================
+
+.PHONY: db-init db-seed db-reset db-migrate db-upgrade
+
+db-init: ## Initialize database (create tables)
+	@echo "$(BLUE)Initializing database...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		. .venv/bin/activate && \
+		uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"
+	@echo "$(GREEN)✓ Database initialized$(NC)"
+
+db-seed: ## Seed database with sample data and default categories
+	@echo "$(BLUE)Seeding database...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		. .venv/bin/activate && \
+		uv run python -m app.seed
+	@echo "$(GREEN)✓ Database seeded$(NC)"
+
+db-reset: ## Reset database (delete and recreate)
+	@echo "$(RED)Resetting database...$(NC)"
+	@rm -f $(BACKEND_DIR)/wallet.db
+	@$(MAKE) db-init
+	@$(MAKE) db-seed
+	@echo "$(GREEN)✓ Database reset complete$(NC)"
+
+db-migrate: ## Create new database migration
+	@echo "$(BLUE)Creating database migration...$(NC)"
+	@read -p "Migration message: " msg; \
+	cd $(BACKEND_DIR) && \
+		. .venv/bin/activate && \
+		uv run alembic revision --autogenerate -m "$$msg"
+	@echo "$(GREEN)✓ Migration created$(NC)"
+
+db-upgrade: ## Apply database migrations
+	@echo "$(BLUE)Applying database migrations...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		. .venv/bin/activate && \
+		uv run alembic upgrade head
+	@echo "$(GREEN)✓ Migrations applied$(NC)"

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -1,0 +1,24 @@
+# =============================================================================
+# Development Targets
+# =============================================================================
+
+.PHONY: backend frontend dev build-frontend
+
+backend: ## Run backend server
+	@echo "$(BLUE)Starting backend server...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		. .venv/bin/activate && \
+		uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+
+frontend: ## Run frontend development server
+	@echo "$(BLUE)Starting frontend server...$(NC)"
+	@cd $(FRONTEND_DIR) && npm run dev
+
+dev: ## Run both backend and frontend (in parallel)
+	@echo "$(BLUE)Starting development servers...$(NC)"
+	@$(MAKE) -j2 backend frontend
+
+build-frontend: ## Build frontend for production
+	@echo "$(BLUE)Building frontend...$(NC)"
+	@cd $(FRONTEND_DIR) && npm run build
+	@echo "$(GREEN)✓ Frontend built$(NC)"

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -1,0 +1,50 @@
+# =============================================================================
+# Docker Targets
+# =============================================================================
+
+.PHONY: docker-build docker-build-force docker-up docker-down docker-logs
+.PHONY: docker-shell docker-clean docker-seed docker-migrate
+
+docker-build: ## Build Docker image
+	@echo "$(BLUE)Building Docker image...$(NC)"
+	docker compose build
+	@echo "$(GREEN)✓ Docker image built$(NC)"
+
+docker-build-force: ## Build Docker image (no cache)
+	@echo "$(BLUE)Building Docker image (no cache)...$(NC)"
+	docker compose build --no-cache
+	@echo "$(GREEN)✓ Docker image built$(NC)"
+
+docker-up: ## Start Docker container
+	@echo "$(BLUE)Starting Docker container...$(NC)"
+	docker compose up -d
+	@echo "$(GREEN)✓ Container started$(NC)"
+	@echo ""
+	@echo "Frontend: http://localhost:3000"
+	@echo "Backend:  http://localhost:8000"
+
+docker-down: ## Stop Docker container
+	@echo "$(BLUE)Stopping Docker container...$(NC)"
+	docker compose down
+	@echo "$(GREEN)✓ Container stopped$(NC)"
+
+docker-logs: ## View Docker logs
+	docker compose logs -f
+
+docker-shell: ## Open shell in Docker container
+	docker compose exec maxwells-wallet /bin/bash
+
+docker-clean: ## Remove Docker containers and volumes
+	@echo "$(RED)Removing Docker containers and volumes...$(NC)"
+	docker compose down -v
+	@echo "$(GREEN)✓ Cleaned$(NC)"
+
+docker-seed: ## Seed database in Docker with sample data
+	@echo "$(BLUE)Seeding database...$(NC)"
+	docker compose run --rm maxwells-wallet seed
+	@echo "$(GREEN)✓ Database seeded$(NC)"
+
+docker-migrate: ## Run database migrations in Docker
+	@echo "$(BLUE)Running migrations...$(NC)"
+	docker compose run --rm maxwells-wallet migrate
+	@echo "$(GREEN)✓ Migrations complete$(NC)"

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,0 +1,51 @@
+# =============================================================================
+# Release Targets
+# =============================================================================
+
+.PHONY: release release-patch release-minor release-major
+
+# Get current version from backend/pyproject.toml
+CURRENT_VERSION := $(shell grep -E '^version = ' $(BACKEND_DIR)/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+
+release: ## Create a release (usage: make release VERSION=x.y.z)
+	@if [ -z "$(VERSION)" ]; then \
+		echo "\033[0;34mRelease Commands:\033[0m"; \
+		echo ""; \
+		echo "  \033[0;33mmake release VERSION=x.y.z\033[0m  - Release specific version"; \
+		echo "  \033[0;33mmake release-patch\033[0m          - $(CURRENT_VERSION) -> next patch"; \
+		echo "  \033[0;33mmake release-minor\033[0m          - $(CURRENT_VERSION) -> next minor"; \
+		echo "  \033[0;33mmake release-major\033[0m          - $(CURRENT_VERSION) -> next major"; \
+		echo ""; \
+		echo "Current version: \033[0;32m$(CURRENT_VERSION)\033[0m"; \
+	else \
+		echo "\033[0;34mCreating release v$(VERSION)...\033[0m"; \
+		sed -i '' 's/^version = ".*"/version = "$(VERSION)"/' $(BACKEND_DIR)/pyproject.toml; \
+		sed -i '' 's/"version": ".*"/"version": "$(VERSION)"/' $(FRONTEND_DIR)/package.json; \
+		./scripts/generate-changelog.sh $(VERSION); \
+		git add -A; \
+		git commit -m "chore: release v$(VERSION)"; \
+		git tag v$(VERSION); \
+		echo "\033[0;34mPushing to GitHub...\033[0m"; \
+		git push origin main --tags; \
+		echo ""; \
+		echo "\033[0;32m✓ Release v$(VERSION) created!\033[0m"; \
+		echo ""; \
+		echo "GitHub Actions will now:"; \
+		echo "  1. Create GitHub Release with changelog"; \
+		echo "  2. Build Docker image"; \
+		echo "  3. Push to ghcr.io/poindexter12/maxwells-wallet:$(VERSION)"; \
+		echo ""; \
+		echo "Monitor progress: \033[0;33mgh run watch\033[0m"; \
+	fi
+
+release-patch: ## Create a patch release (x.y.Z+1)
+	@NEW_VERSION=$$(echo $(CURRENT_VERSION) | awk -F. '{print $$1"."$$2"."$$3+1}'); \
+	$(MAKE) release VERSION=$$NEW_VERSION
+
+release-minor: ## Create a minor release (x.Y+1.0)
+	@NEW_VERSION=$$(echo $(CURRENT_VERSION) | awk -F. '{print $$1"."$$2+1".0"}'); \
+	$(MAKE) release VERSION=$$NEW_VERSION
+
+release-major: ## Create a major release (X+1.0.0)
+	@NEW_VERSION=$$(echo $(CURRENT_VERSION) | awk -F. '{print $$1+1".0.0"}'); \
+	$(MAKE) release VERSION=$$NEW_VERSION

--- a/make/test.mk
+++ b/make/test.mk
@@ -1,0 +1,110 @@
+# =============================================================================
+# Testing Targets
+# =============================================================================
+
+.PHONY: test-backend test-unit test-reports test-tags test-import test-budgets
+.PHONY: test-e2e-install test-e2e test-e2e-headed test-e2e-debug test-e2e-import test-e2e-full
+.PHONY: test-all lint-frontend
+
+# -----------------------------------------------------------------------------
+# Unit & Integration Tests
+# -----------------------------------------------------------------------------
+
+test-backend: ## Run backend tests
+	@echo "$(BLUE)Running backend tests...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		.venv/bin/python -m pytest --ignore=tests/e2e -v
+	@echo "$(GREEN)✓ Tests complete$(NC)"
+
+test-unit: test-backend ## Run unit/integration tests (alias)
+
+test-reports: ## Run report/analytics tests only
+	@echo "$(BLUE)Running report tests...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		.venv/bin/python -m pytest tests/test_reports.py tests/test_new_analytics.py -v
+	@echo "$(GREEN)✓ Report tests complete$(NC)"
+
+test-tags: ## Run tag system tests only
+	@echo "$(BLUE)Running tag system tests...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		.venv/bin/python -m pytest tests/test_tags.py tests/test_tag_rules.py -v
+	@echo "$(GREEN)✓ Tag system tests complete$(NC)"
+
+test-import: ## Run CSV import tests only
+	@echo "$(BLUE)Running import tests...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		.venv/bin/python -m pytest tests/test_csv_import.py -v
+	@echo "$(GREEN)✓ Import tests complete$(NC)"
+
+test-budgets: ## Run budget tests only
+	@echo "$(BLUE)Running budget tests...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		.venv/bin/python -m pytest tests/test_budgets.py -v
+	@echo "$(GREEN)✓ Budget tests complete$(NC)"
+
+# -----------------------------------------------------------------------------
+# End-to-End Tests (Playwright)
+# -----------------------------------------------------------------------------
+
+test-e2e-install: ## Install Playwright browsers for E2E tests
+	@echo "$(BLUE)Installing Playwright browsers...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		. .venv/bin/activate && \
+		uv pip install pytest-playwright playwright && \
+		playwright install chromium
+	@echo "$(GREEN)✓ Playwright browsers installed$(NC)"
+
+test-e2e: ## Run E2E validation tests (requires 'make dev' running)
+	@echo "$(BLUE)Running E2E validation tests...$(NC)"
+	@echo "$(YELLOW)Checking if servers are running...$(NC)"
+	@curl -s http://localhost:8000/api/v1/transactions >/dev/null 2>&1 || { echo "$(RED)Backend not running. Start with: make dev$(NC)"; exit 1; }
+	@curl -s http://localhost:3000 >/dev/null 2>&1 || { echo "$(RED)Frontend not running. Start with: make dev$(NC)"; exit 1; }
+	@echo "$(GREEN)Servers detected, running tests...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		.venv/bin/python -m pytest tests/e2e -v --tb=short
+	@echo "$(GREEN)✓ E2E tests complete$(NC)"
+
+test-e2e-headed: ## Run E2E tests with visible browser
+	@echo "$(BLUE)Running E2E tests (headed mode)...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		.venv/bin/python -m pytest tests/e2e -v --headed --tb=short
+	@echo "$(GREEN)✓ E2E tests complete$(NC)"
+
+test-e2e-debug: ## Run E2E tests in debug mode (slow, with browser visible)
+	@echo "$(BLUE)Running E2E tests in debug mode...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		PWDEBUG=1 .venv/bin/python -m pytest tests/e2e -v -s --headed
+	@echo "$(GREEN)✓ E2E debug session complete$(NC)"
+
+test-e2e-import: ## Run only import workflow E2E tests
+	@echo "$(BLUE)Running import workflow E2E tests...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		.venv/bin/python -m pytest tests/e2e/test_import_workflow.py -v
+	@echo "$(GREEN)✓ Import E2E tests complete$(NC)"
+
+test-e2e-full: ## Run full workflow E2E tests (slow)
+	@echo "$(BLUE)Running full workflow E2E tests...$(NC)"
+	@cd $(BACKEND_DIR) && \
+		unset VIRTUAL_ENV && \
+		.venv/bin/python -m pytest tests/e2e/test_full_workflow.py -v --tb=short
+	@echo "$(GREEN)✓ Full workflow E2E tests complete$(NC)"
+
+test-all: test-backend test-e2e ## Run all tests (unit + E2E)
+
+# -----------------------------------------------------------------------------
+# Linting
+# -----------------------------------------------------------------------------
+
+lint-frontend: ## Lint frontend code
+	@echo "$(BLUE)Linting frontend...$(NC)"
+	@cd $(FRONTEND_DIR) && npm run lint
+	@echo "$(GREEN)✓ Linting complete$(NC)"

--- a/make/utils.mk
+++ b/make/utils.mk
@@ -1,0 +1,88 @@
+# =============================================================================
+# Utility Targets
+# =============================================================================
+
+.PHONY: clean clean-all status info check-deps
+.PHONY: anonymize anonymize-status anonymize-force
+
+# -----------------------------------------------------------------------------
+# Cleaning
+# -----------------------------------------------------------------------------
+
+clean: ## Clean build artifacts and caches
+	@echo "$(BLUE)Cleaning build artifacts...$(NC)"
+	@rm -rf $(BACKEND_DIR)/__pycache__
+	@rm -rf $(BACKEND_DIR)/.pytest_cache
+	@rm -rf $(BACKEND_DIR)/app/__pycache__
+	@rm -rf $(BACKEND_DIR)/app/routers/__pycache__
+	@rm -rf $(FRONTEND_DIR)/.next
+	@rm -rf $(FRONTEND_DIR)/out
+	@rm -rf $(FRONTEND_DIR)/node_modules/.cache
+	@echo "$(GREEN)✓ Cleaned$(NC)"
+
+clean-all: clean ## Clean everything including dependencies and database
+	@echo "$(RED)Cleaning all dependencies and database...$(NC)"
+	@rm -rf $(BACKEND_DIR)/.venv
+	@rm -rf $(FRONTEND_DIR)/node_modules
+	@rm -f $(BACKEND_DIR)/wallet.db
+	@echo "$(GREEN)✓ All cleaned$(NC)"
+
+# -----------------------------------------------------------------------------
+# Status & Info
+# -----------------------------------------------------------------------------
+
+status: ## Check status of services
+	@echo "$(BLUE)Service Status:$(NC)"
+	@echo ""
+	@echo "Backend:"
+	@curl -s http://localhost:8000/health 2>/dev/null && echo "$(GREEN)  ✓ Running at http://localhost:8000$(NC)" || echo "$(RED)  ✗ Not running$(NC)"
+	@echo ""
+	@echo "Frontend:"
+	@curl -s http://localhost:3000 >/dev/null 2>&1 && echo "$(GREEN)  ✓ Running at http://localhost:3000$(NC)" || echo "$(RED)  ✗ Not running$(NC)"
+	@echo ""
+
+info: ## Show project information
+	@echo "$(BLUE)Maxwell's Wallet - Personal Finance Tracker$(NC)"
+	@echo ""
+	@echo "Project: maxwells-wallet"
+	@echo "Backend:  FastAPI + Python + SQLModel"
+	@echo "Frontend: Next.js + TypeScript + Tailwind CSS"
+	@echo ""
+	@echo "$(GREEN)Features:$(NC)"
+	@echo "  • CSV import (BOFA, AMEX, Venmo, Inspira HSA)"
+	@echo "  • Smart categorization with rules"
+	@echo "  • Monthly spending analysis"
+	@echo "  • Budget tracking"
+	@echo "  • Transfer detection"
+	@echo "  • Merchant aliases"
+	@echo ""
+	@echo "$(YELLOW)Quick Start:$(NC)"
+	@echo "  1. make setup      # First-time setup"
+	@echo "  2. make dev        # Start development servers"
+	@echo "  3. Open http://localhost:3000"
+	@echo ""
+
+check-deps: ## Check if required dependencies are installed
+	@echo "$(BLUE)Checking dependencies...$(NC)"
+	@command -v python3 >/dev/null 2>&1 || { echo "$(RED)✗ Python 3 not found$(NC)"; exit 1; }
+	@command -v uv >/dev/null 2>&1 || { echo "$(RED)✗ uv not found. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh$(NC)"; exit 1; }
+	@command -v node >/dev/null 2>&1 || { echo "$(RED)✗ Node.js not found$(NC)"; exit 1; }
+	@command -v npm >/dev/null 2>&1 || { echo "$(RED)✗ npm not found. Install Node.js from nodejs.org$(NC)"; exit 1; }
+	@echo "$(GREEN)✓ All dependencies found$(NC)"
+
+# -----------------------------------------------------------------------------
+# Test Data Anonymization
+# -----------------------------------------------------------------------------
+
+anonymize: ## Anonymize CSV files in data/raw/ -> data/anonymized/
+	@echo "$(BLUE)Anonymizing test data...$(NC)"
+	@cd $(BACKEND_DIR) && . .venv/bin/activate && python ../scripts/anonymize_import.py
+	@echo "$(GREEN)✓ Anonymization complete$(NC)"
+
+anonymize-status: ## Show status of anonymized test data
+	@cd $(BACKEND_DIR) && . .venv/bin/activate && python ../scripts/anonymize_import.py --status
+
+anonymize-force: ## Force re-anonymize all test data files
+	@echo "$(BLUE)Force re-anonymizing all test data...$(NC)"
+	@cd $(BACKEND_DIR) && . .venv/bin/activate && python ../scripts/anonymize_import.py --force
+	@echo "$(GREEN)✓ Anonymization complete$(NC)"


### PR DESCRIPTION
## Summary
- Reorganizes the monolithic 370-line Makefile into logical modules under `make/`
- Adds comprehensive documentation in `docs/MAKEFILE.md`
- Fixes help command to show all targets (including `test-e2e-*`)

## Structure
```
Makefile              # Main entry - shared vars, help, includes
make/
  dev.mk              # Development: backend, frontend, dev
  db.mk               # Database: init, seed, migrate
  test.mk             # Testing: unit, e2e, lint
  docker.mk           # Docker: build, up, down
  release.mk          # Release automation
  utils.mk            # Utilities: clean, status, info
```

## Test plan
- [x] `make help` shows all commands
- [x] `make release` shows usage correctly
- [x] `make status` works
- [x] All test-e2e-* commands appear in help