### PR TITLE
docs: add developer guide, trim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,7 @@
 
 Personal finance tracker with CSV import, smart categorization, and spending trend analysis.
 
-Built with:
-- **Frontend**: Next.js 14 + TypeScript + Tailwind CSS
-- **Backend**: FastAPI + Python (async)
-- **Database**: SQLite (dev) with SQLModel ORM
-- **Charts**: Recharts
-
-📋 **[Full Requirements & Specifications →](docs/requirements/)**
+**[Documentation](https://docs.maxwellswallet.com)** · **[Requirements](docs/requirements/)**
 
 ## What's New
 
@@ -54,305 +48,47 @@ See [CHANGELOG.md](CHANGELOG.md) for full release history.
 - **Credit Card Tracking**: Due dates, credit limits, available credit, utilization %
 - **Category Rules**: Automate categorization with pattern-based rules
 
-### Navigation
-- **Dashboard** - Monthly summary, charts, trends, anomalies
-- **Transactions** - Browse, filter, search, bulk edit
-- **Budgets** - Spending limits with progress tracking
-- **Organize** - Buckets, Occasions, and Accounts
-- **Tools** - Transfers, Rules, and Merchant aliases
-- **Admin** - Import history, data management
-
 ## Quick Start
 
-### Using Docker (Recommended)
+### Docker (Recommended)
 
 ```bash
-# Build and run with Docker Compose
 docker compose up -d
-
 # Open http://localhost:3000
 ```
 
-Your data is persisted in a Docker volume. To use a custom location:
+Data persists in a Docker volume. For a custom location:
+
 ```bash
-# Mount a specific host directory
-docker run -d \
-  -p 3000:3000 -p 8000:8000 \
-  -v /path/to/your/data:/data \
-  maxwells-wallet
+docker run -d -p 3000:3000 -p 8000:8000 -v /path/to/data:/data maxwells-wallet
 ```
 
-### Using Makefile (Development)
+### Development
 
 ```bash
-# First-time setup (installs dependencies + seeds database)
-make setup
-
-# Start development servers (backend + frontend)
-make dev
-
+make setup    # First-time setup
+make dev      # Start servers
 # Open http://localhost:3000
 ```
 
-**Common Makefile commands:**
 ```bash
-make help             # Show all available commands
-make setup            # First-time setup
-make dev              # Start both servers
-make backend          # Start backend only
-make frontend         # Start frontend only
-make db-reset         # Reset database
-make db-seed          # Seed sample data
-make test-backend     # Run backend tests
-make anonymize        # Anonymize test data (see below)
-make anonymize-status # Check anonymization status
-make clean            # Clean build artifacts
-make status           # Check if services are running
+make help     # Show all commands
 ```
-
-### Using setup.sh (Alternative)
-
-```bash
-./setup.sh         # Run setup script
-make dev           # Start servers
-```
-
-## Manual Setup
-
-### Prerequisites
-
-- Python 3.11+
-- Node.js 18+ (includes npm)
-- uv (install: `curl -LsSf https://astral.sh/uv/install.sh | sh`)
-
-### Backend Setup
-
-1. Navigate to backend directory:
-   ```bash
-   cd backend
-   ```
-
-2. Create virtual environment and install dependencies:
-   ```bash
-   uv venv
-   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-   uv pip install -e .
-   ```
-
-3. Seed the database with sample data:
-   ```bash
-   uv run python -m app.seed
-   ```
-
-4. Start the backend server:
-   ```bash
-   cd backend
-   uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
-   ```
-
-   The API will be available at http://localhost:8000
-
-### Frontend Setup
-
-1. Navigate to frontend directory:
-   ```bash
-   cd frontend
-   ```
-
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-
-3. Start the development server:
-   ```bash
-   npm run dev
-   ```
-
-   The app will be available at http://localhost:3000
 
 ## Usage
 
-### Importing Transactions
+1. **Import** - Upload CSV/QIF/QFX files from your bank
+2. **Reconcile** - Review and categorize transactions
+3. **Dashboard** - View spending summaries, charts, and trends
 
-1. Navigate to the **Import** page
-2. Upload a CSV file (sample files in `/samples/`)
-3. Optionally specify account source (required for BOFA files)
-4. Preview the import
-5. Confirm to import transactions into the database
+## Documentation
 
-### Reconciling Transactions
+Full documentation is available at **[docs.maxwellswallet.com](https://docs.maxwellswallet.com)**:
 
-1. Navigate to the **Reconcile** page
-2. Review unreconciled transactions
-3. Assign categories as needed
-4. Select transactions and mark as reconciled or ignored
-
-### Viewing Dashboard
-
-The dashboard shows:
-- Current month income, expenses, and net
-- Spending by category (pie chart)
-- Top merchants
-- 6-month spending trend (line chart)
-
-## Project Structure
-
-```
-maxwells-wallet/
-├── backend/                 # FastAPI backend
-│   ├── app/
-│   │   ├── main.py         # FastAPI app entry point
-│   │   ├── models.py       # SQLModel database models
-│   │   ├── database.py     # Database configuration
-│   │   ├── csv_parser.py   # CSV parsing logic (BOFA/AMEX)
-│   │   ├── category_inference.py  # Category inference service
-│   │   ├── seed.py         # Database seeding script
-│   │   └── routers/        # API route handlers
-│   │       ├── transactions.py
-│   │       ├── categories.py
-│   │       ├── import_router.py
-│   │       └── reports.py
-│   ├── alembic/            # Database migrations
-│   └── pyproject.toml      # Python dependencies
-├── frontend/               # Next.js frontend
-│   ├── src/
-│   │   └── app/
-│   │       ├── layout.tsx  # App layout with navigation
-│   │       ├── page.tsx    # Dashboard page
-│   │       ├── transactions/  # Transactions page
-│   │       ├── import/     # Import page
-│   │       └── reconcile/  # Reconciliation page
-│   ├── package.json        # Node dependencies
-│   └── next.config.js      # Next.js config (API proxy)
-├── samples/                # Sample CSV files (seeding)
-│   ├── bofa.csv
-│   └── amex.csv
-├── data/                   # Test data directory
-│   ├── raw/                # Real financial CSVs (gitignored)
-│   └── anonymized/         # Scrubbed test data (safe to commit)
-├── scripts/                # Utility scripts
-│   └── anonymize_import.py # Data anonymization tool
-└── forge.config.yaml       # Project configuration
-```
-
-## API Endpoints
-
-### Transactions
-- `GET /api/v1/transactions` - List transactions with filtering
-- `GET /api/v1/transactions/{id}` - Get single transaction
-- `POST /api/v1/transactions` - Create transaction
-- `PATCH /api/v1/transactions/{id}` - Update transaction
-- `DELETE /api/v1/transactions/{id}` - Delete transaction
-- `POST /api/v1/transactions/{id}/suggest-category` - Get category suggestions
-- `POST /api/v1/transactions/bulk-update` - Bulk update transactions
-
-### Categories
-- `GET /api/v1/categories` - List all categories
-- `POST /api/v1/categories` - Create category
-- `PATCH /api/v1/categories/{id}` - Update category
-- `DELETE /api/v1/categories/{id}` - Delete category
-
-### Import
-- `POST /api/v1/import/preview` - Preview CSV import
-- `POST /api/v1/import/confirm` - Confirm and import CSV
-- `GET /api/v1/import/formats` - List saved import formats
-
-### Reports (Basic)
-- `GET /api/v1/reports/monthly-summary` - Monthly spending summary
-- `GET /api/v1/reports/trends` - Spending trends over time
-- `GET /api/v1/reports/top-merchants` - Top merchants by spending
-- `GET /api/v1/reports/account-summary` - Summary by account
-
-### Reports (Advanced Analytics)
-- `GET /api/v1/reports/month-over-month` - Compare current vs previous month
-- `GET /api/v1/reports/spending-velocity` - Daily burn rate and projections
-- `GET /api/v1/reports/anomalies` - Detect unusual transactions (includes dynamic threshold)
-
-### Filters & Export
-- `GET /api/v1/filters` - List saved filters
-- `POST /api/v1/filters` - Create saved filter
-- `GET /api/v1/filters/{id}/apply` - Apply saved filter
-- `GET /api/v1/transactions/export` - Export filtered transactions to CSV
-
-### Account Management
-- `GET /api/v1/accounts` - List accounts with credit card details
-- `PATCH /api/v1/accounts/{id}` - Update account (credit limit, due date, etc.)
-
-## Default Categories
-
-- Income
-- Groceries
-- Dining & Coffee
-- Shopping
-- Utilities
-- Transportation
-- Entertainment
-- Healthcare
-- Education
-- Housing
-- Subscriptions
-- Other
-
-You can add/delete categories via the Categories API.
-
-## Test Data
-
-### Quick Samples
-
-The `/samples/` directory contains sample CSV files for database seeding. These are imported when running `make db-seed`.
-
-### Anonymizing Real Data
-
-To test with realistic data without exposing sensitive information, use the anonymization tool:
-
-```bash
-# 1. Put your real bank CSVs in data/raw/ (gitignored)
-cp ~/Downloads/amex_statement.csv data/raw/
-cp ~/Downloads/bofa_checking.csv data/raw/
-
-# 2. Check what needs processing
-make anonymize-status
-
-# 3. Anonymize all new/changed files
-make anonymize
-
-# 4. Find scrubbed files in data/anonymized/
-ls data/anonymized/
-```
-
-**How it works:**
-- Merchants are consistently tokenized: "AMAZON" → "Acme Store" (same fake name everywhere)
-- Account numbers, card member names, and reference IDs are replaced
-- Amounts and dates are preserved for realistic testing
-- A manifest tracks file hashes so unchanged files are skipped on re-runs
-
-**Commands:**
-```bash
-make anonymize         # Process new/changed files
-make anonymize-status  # Show pending/processed files
-make anonymize-force   # Reprocess all files
-```
-
-The anonymized files in `data/anonymized/` are safe to commit and share.
-
-## Development
-
-### Database Migrations
-
-```bash
-cd backend
-uv run alembic revision --autogenerate -m "description"
-uv run alembic upgrade head
-```
-
-### Reset Database
-
-```bash
-cd backend
-rm wallet.db
-uv run python -m app.seed
-```
+- [Getting Started](https://docs.maxwellswallet.com/getting-started/quickstart/)
+- [Features Guide](https://docs.maxwellswallet.com/features/import/)
+- [API Reference](https://docs.maxwellswallet.com/api/overview/)
+- [Developer Guide](https://docs.maxwellswallet.com/developer/architecture/)
 
 ## License
 

--- a/docs-site/developer/architecture.md
+++ b/docs-site/developer/architecture.md
@@ -1,0 +1,120 @@
+# Architecture
+
+Maxwell's Wallet is a full-stack application with a Python backend and TypeScript frontend.
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Frontend | Next.js 14 + TypeScript + Tailwind CSS |
+| Backend | FastAPI + Python (async) |
+| Database | SQLite (dev) / PostgreSQL (prod) |
+| ORM | SQLModel (Pydantic + SQLAlchemy) |
+| Charts | Recharts |
+| Package Management | pnpm (frontend), uv (backend) |
+
+## Project Structure
+
+```
+maxwells-wallet/
+├── backend/                 # FastAPI backend
+│   ├── app/
+│   │   ├── main.py         # FastAPI app entry point
+│   │   ├── models.py       # SQLModel database models
+│   │   ├── database.py     # Database configuration
+│   │   ├── csv_parser.py   # CSV parsing logic (BOFA/AMEX)
+│   │   ├── category_inference.py  # Category inference service
+│   │   ├── seed.py         # Database seeding script
+│   │   └── routers/        # API route handlers
+│   │       ├── transactions.py
+│   │       ├── categories.py
+│   │       ├── import_router.py
+│   │       └── reports.py
+│   ├── alembic/            # Database migrations
+│   ├── tests/              # Backend test suite
+│   └── pyproject.toml      # Python dependencies
+├── frontend/               # Next.js frontend
+│   ├── src/
+│   │   └── app/
+│   │       ├── layout.tsx  # App layout with navigation
+│   │       ├── page.tsx    # Dashboard page
+│   │       ├── transactions/  # Transactions page
+│   │       ├── import/     # Import page
+│   │       └── reconcile/  # Reconciliation page
+│   ├── package.json        # Node dependencies
+│   └── next.config.js      # Next.js config (API proxy)
+├── samples/                # Sample CSV files (seeding)
+├── data/                   # Test data directory
+│   ├── raw/                # Real financial CSVs (gitignored)
+│   └── anonymized/         # Scrubbed test data (safe to commit)
+├── scripts/                # Utility scripts
+├── make/                   # Modular Makefile components
+└── docs-site/              # MkDocs documentation source
+```
+
+## Backend Architecture
+
+### API Design
+
+The backend follows a router-based architecture with FastAPI:
+
+- **Routers** handle HTTP endpoints, grouped by domain
+- **Models** define SQLModel entities (Pydantic + SQLAlchemy hybrid)
+- **Services** contain business logic (category inference, CSV parsing)
+
+### Key Patterns
+
+- **Async everywhere**: All database operations use async/await
+- **SQLModel**: Single model definitions serve as both Pydantic schemas and SQLAlchemy ORM models
+- **Alembic**: Database migrations for schema changes
+
+### Database
+
+SQLite is used for development with the database file at `backend/wallet.db`. The schema is PostgreSQL-compatible for production deployment.
+
+Key entities:
+
+- `Transaction` - Financial transactions with amount, date, merchant
+- `Account` - Bank accounts and credit cards
+- `Bucket` - Spending categories (Groceries, Dining, etc.)
+- `Occasion` - Time-based groupings (Christmas 2024, Vacation, etc.)
+- `TagRule` - Pattern-based auto-categorization rules
+- `Budget` - Spending limits per bucket/occasion/account
+
+## Frontend Architecture
+
+### Next.js App Router
+
+The frontend uses Next.js 14 with the App Router:
+
+- **Server Components** by default for better performance
+- **Client Components** where interactivity is needed (`'use client'`)
+- **API Proxy** configured in `next.config.js` to route `/api/*` to the backend
+
+### State Management
+
+- React hooks for local state
+- Server-side data fetching where possible
+- Client-side fetching for interactive features
+
+### Styling
+
+- **Tailwind CSS** for utility-first styling
+- Consistent color scheme with blue primary accent
+- Responsive design for desktop and mobile
+
+## API Communication
+
+The frontend communicates with the backend via REST API:
+
+```
+Frontend (localhost:3000)
+    ↓
+Next.js API Proxy (/api/* → localhost:8000/api/*)
+    ↓
+FastAPI Backend (localhost:8000)
+    ↓
+SQLite Database (wallet.db)
+```
+
+This proxy setup allows the frontend to make API calls to `/api/v1/...` without CORS issues during development.

--- a/docs-site/developer/database.md
+++ b/docs-site/developer/database.md
@@ -1,0 +1,116 @@
+# Database
+
+Maxwell's Wallet uses SQLite for development and is PostgreSQL-compatible for production.
+
+## Schema Management
+
+Database schema is managed with [Alembic](https://alembic.sqlalchemy.org/) migrations.
+
+### Creating Migrations
+
+When you modify models in `backend/app/models.py`:
+
+```bash
+cd backend
+uv run alembic revision --autogenerate -m "description of change"
+```
+
+Review the generated migration in `backend/alembic/versions/` before applying.
+
+### Applying Migrations
+
+```bash
+cd backend
+uv run alembic upgrade head
+```
+
+### Migration History
+
+```bash
+# Show current revision
+uv run alembic current
+
+# Show migration history
+uv run alembic history
+
+# Downgrade one revision
+uv run alembic downgrade -1
+```
+
+## Seeding
+
+### Sample Data
+
+Populate the database with sample transactions:
+
+```bash
+make db-seed
+```
+
+This imports sample CSV files from `/samples/` and creates default categories.
+
+### Reset Database
+
+To start fresh:
+
+```bash
+make db-reset
+```
+
+Or manually:
+
+```bash
+cd backend
+rm wallet.db
+uv run python -m app.seed
+```
+
+## Database Location
+
+| Environment | Location |
+|-------------|----------|
+| Development | `backend/wallet.db` |
+| Docker | `/data/wallet.db` (mounted volume) |
+| Production | Configure via `DATABASE_URL` env var |
+
+## Entity Reference
+
+See [Domain Model](../domain-model.md) for detailed entity documentation.
+
+### Core Entities
+
+| Entity | Description |
+|--------|-------------|
+| `Transaction` | Financial transactions (amount, date, merchant) |
+| `Account` | Bank accounts and credit cards |
+| `Bucket` | Spending categories (Groceries, Dining, etc.) |
+| `Occasion` | Time-based groupings (Christmas 2024, Vacation) |
+
+### Supporting Entities
+
+| Entity | Description |
+|--------|-------------|
+| `TagRule` | Pattern-based auto-categorization rules |
+| `Budget` | Spending limits per bucket/occasion/account |
+| `MerchantAlias` | Normalize messy merchant names |
+| `ImportSession` | Track import history and duplicates |
+| `SavedFilter` | User-saved filter presets |
+
+## Default Categories
+
+The seed script creates these default buckets:
+
+- Income
+- Groceries
+- Dining & Coffee
+- Shopping
+- Utilities
+- Transportation
+- Entertainment
+- Healthcare
+- Education
+- Housing
+- Subscriptions
+- Other
+
+Additional categories can be created via the API or UI.

--- a/docs-site/developer/testing.md
+++ b/docs-site/developer/testing.md
@@ -1,0 +1,123 @@
+# Testing
+
+## Running Tests
+
+### Backend Tests
+
+```bash
+# Run all backend tests (unit + integration)
+make test-backend
+
+# Run with coverage report
+make test-coverage
+
+# Run specific test suites
+make test-reports     # Report/analytics tests
+make test-tags        # Tag system tests
+make test-import      # CSV import tests
+make test-budgets     # Budget tests
+```
+
+### E2E Tests (Playwright)
+
+E2E tests require the development servers to be running.
+
+```bash
+# Install Playwright browsers (first time only)
+make test-e2e-install
+
+# Run E2E tests (headless)
+make test-e2e
+
+# Run E2E tests with visible browser
+make test-e2e-headed
+
+# Run E2E tests in debug mode
+make test-e2e-debug
+
+# Run specific E2E test suites
+make test-e2e-import  # Import workflow tests
+make test-e2e-full    # Full workflow tests
+```
+
+### All Tests
+
+```bash
+# Run both unit and E2E tests
+make test-all
+```
+
+### Frontend Linting
+
+```bash
+make lint-frontend
+```
+
+## Test Data
+
+### Quick Samples
+
+The `/samples/` directory contains sample CSV files for database seeding:
+
+- `bofa.csv` - Bank of America checking format
+- `amex.csv` - American Express format
+
+These are imported when running `make db-seed`.
+
+### Anonymizing Real Data
+
+To test with realistic data without exposing sensitive information, use the anonymization tool.
+
+#### Setup
+
+```bash
+# 1. Put your real bank CSVs in data/raw/ (gitignored)
+cp ~/Downloads/amex_statement.csv data/raw/
+cp ~/Downloads/bofa_checking.csv data/raw/
+
+# 2. Check what needs processing
+make anonymize-status
+
+# 3. Anonymize all new/changed files
+make anonymize
+
+# 4. Find scrubbed files in data/anonymized/
+ls data/anonymized/
+```
+
+#### How Anonymization Works
+
+- **Merchants** are consistently tokenized: "AMAZON" → "Acme Store" (same fake name everywhere)
+- **Account numbers**, card member names, and reference IDs are replaced
+- **Amounts and dates** are preserved for realistic testing
+- A **manifest** tracks file hashes so unchanged files are skipped on re-runs
+
+#### Commands
+
+```bash
+make anonymize         # Process new/changed files
+make anonymize-status  # Show pending/processed files
+make anonymize-force   # Reprocess all files
+```
+
+The anonymized files in `data/anonymized/` are safe to commit and share.
+
+## Coverage
+
+Test coverage is tracked via [Codecov](https://codecov.io/gh/poindexter12/maxwells-wallet).
+
+To generate a local coverage report:
+
+```bash
+make test-coverage
+# Report saved to backend/htmlcov/
+open backend/htmlcov/index.html
+```
+
+## CI/CD
+
+Tests run automatically on every push and pull request via GitHub Actions:
+
+- **CI Workflow** (`.github/workflows/ci.yml`): Runs backend tests with coverage
+- Coverage results are uploaded to Codecov
+- PRs show coverage diff in comments

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,10 @@ nav:
     - Transactions: api/transactions.md
     - Reports: api/reports.md
     - Import: api/import.md
+  - Developer Guide:
+    - Architecture: developer/architecture.md
+    - Database: developer/database.md
+    - Testing: developer/testing.md
   - Domain Model: domain-model.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary
- Create `docs-site/developer/` section with architecture, database, and testing guides
- Move detailed developer content (manual setup, project structure, API endpoints, test data) from README to dedicated docs
- Add link to docs.maxwellswallet.com in README
- README now focused on features and quick start (~95 lines vs ~360)

## Changes
- **New**: `docs-site/developer/architecture.md` - project structure, tech stack, patterns
- **New**: `docs-site/developer/database.md` - migrations, seeding, entity reference
- **New**: `docs-site/developer/testing.md` - test commands, coverage, anonymization
- **Updated**: `mkdocs.yml` - added Developer Guide nav section
- **Updated**: `README.md` - trimmed and added docs link

## Test plan
- [ ] Verify docs build locally: `mkdocs serve`
- [ ] Check README renders correctly on GitHub
- [ ] Verify docs deploy to docs.maxwellswallet.com after merge