### PR TITLE
refactor(frontend): extract transactions page into modular components

### DIFF
--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -2,62 +2,15 @@
 
 import { useEffect, useState, useRef, useCallback, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { format } from 'date-fns'
 import Link from 'next/link'
-import { formatCurrency } from '@/lib/format'
 import { PageHelp } from '@/components/PageHelp'
-import { HelpTip } from '@/components/Tooltip'
-import { SplitTransaction } from '@/components/SplitTransaction'
-
-interface Tag {
-  id: number
-  namespace: string
-  value: string
-  description?: string
-}
-
-interface TransactionTag {
-  namespace: string
-  value: string
-  full: string
-}
-
-interface Transaction {
-  id: number
-  date: string
-  amount: number
-  description: string
-  merchant: string | null
-  account_source: string
-  account_tag_id: number | null  // FK to account tag
-  category: string | null  // Legacy field
-  reconciliation_status: string
-  notes?: string | null
-  tags?: TransactionTag[]
-  bucket?: string  // Convenience field we'll compute
-  account?: string  // Convenience field we'll compute from account tag
-  is_transfer?: boolean  // True if marked as internal transfer
-  linked_transaction_id?: number | null  // ID of linked transfer pair
-}
+import { Tag, Transaction, TransactionTag, TransactionFilters, INITIAL_FILTERS } from '@/types/transactions'
+import { useBulkSelection } from '@/hooks/useBulkSelection'
+import TransactionFiltersComponent from '@/components/transactions/TransactionFilters'
+import BulkActionsBar from '@/components/transactions/BulkActionsBar'
+import TransactionRow from '@/components/transactions/TransactionRow'
 
 const PAGE_SIZE = 50
-
-// Bucket color mapping for left border
-const BUCKET_COLORS: Record<string, string> = {
-  'groceries': 'border-l-green-500',
-  'dining': 'border-l-orange-500',
-  'entertainment': 'border-l-purple-500',
-  'transportation': 'border-l-blue-500',
-  'utilities': 'border-l-yellow-500',
-  'housing': 'border-l-indigo-500',
-  'healthcare': 'border-l-red-500',
-  'shopping': 'border-l-pink-500',
-  'subscriptions': 'border-l-cyan-500',
-  'education': 'border-l-teal-500',
-  'income': 'border-l-emerald-500',
-  'other': 'border-l-gray-400',
-  'none': 'border-l-gray-300',
-}
 
 // Wrapper component with Suspense boundary for useSearchParams
 export default function TransactionsPage() {
@@ -71,63 +24,40 @@ export default function TransactionsPage() {
 function TransactionsContent() {
   const searchParams = useSearchParams()
 
+  // Transaction data
   const [transactions, setTransactions] = useState<Transaction[]>([])
   const [totalCount, setTotalCount] = useState<number>(0)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState(true)
+
+  // Tags data
   const [bucketTags, setBucketTags] = useState<Tag[]>([])
   const [allTags, setAllTags] = useState<Tag[]>([])
   const [accountTags, setAccountTags] = useState<Tag[]>([])
   const [occasionTags, setOccasionTags] = useState<Tag[]>([])
-  const [loading, setLoading] = useState(true)
-  const [loadingMore, setLoadingMore] = useState(false)
-  const [hasMore, setHasMore] = useState(true)
-  const [filtersInitialized, setFiltersInitialized] = useState(false)
-  const [filters, setFilters] = useState({
-    search: '',
-    bucket: '',
-    occasion: '',
-    accounts: [] as string[],        // Multiple account selection
-    accountsExclude: [] as string[], // Accounts to exclude
-    status: '',
-    amountMin: '',
-    amountMax: '',
-    startDate: '',
-    endDate: '',
-    transfers: 'hide' as 'all' | 'hide' | 'only'  // Transfer filter: all, hide, only
-  })
-  // Separate state for search input to prevent refetch on every keystroke
-  const [searchInput, setSearchInput] = useState('')
-  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false)
-  const [showAccountDropdown, setShowAccountDropdown] = useState(false)
-  const [addingTagTo, setAddingTagTo] = useState<number | null>(null)
-  const [newTagValue, setNewTagValue] = useState('')
 
-  // Bulk selection state
-  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
-  const [bulkAction, setBulkAction] = useState('')
-  const [bulkValue, setBulkValue] = useState('')
-  const [bulkLoading, setBulkLoading] = useState(false)
+  // Filter state
+  const [filters, setFilters] = useState<TransactionFilters>(INITIAL_FILTERS)
+  const [searchInput, setSearchInput] = useState('')
+  const [filtersInitialized, setFiltersInitialized] = useState(false)
+  const [largeThreshold, setLargeThreshold] = useState<number | null>(null)
+
+  // Bulk selection (using extracted hook)
+  const bulkSelection = useBulkSelection<Transaction>()
 
   // Expanded rows for metadata
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set())
-
-  // Inline notes editing
-  const [editingNoteId, setEditingNoteId] = useState<number | null>(null)
-  const [noteValue, setNoteValue] = useState('')
-
-  // Dynamic large transaction threshold (from anomaly detection)
-  const [largeThreshold, setLargeThreshold] = useState<number | null>(null)
 
   // Infinite scroll refs
   const observerRef = useRef<IntersectionObserver | null>(null)
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
 
-  // Initialize filters from URL params on mount and when URL changes
-  // Using searchParams.toString() ensures we detect all URL param changes
+  // Initialize filters from URL params
   const searchParamsString = searchParams.toString()
   useEffect(() => {
     const bucket = searchParams.get('bucket') || ''
     const occasion = searchParams.get('occasion') || ''
-    // Support both single 'account' param and multiple 'accounts' params
     const accountSingle = searchParams.get('account') || ''
     const accountsMulti = searchParams.getAll('accounts')
     const accountsExclude = searchParams.getAll('accounts_exclude')
@@ -140,16 +70,7 @@ function TransactionsContent() {
     const transfersParam = searchParams.get('transfers') || 'hide'
     const transfers = (['all', 'hide', 'only'].includes(transfersParam) ? transfersParam : 'hide') as 'all' | 'hide' | 'only'
 
-    // Combine single account with multi-accounts
-    const accounts = accountSingle
-      ? [accountSingle, ...accountsMulti]
-      : accountsMulti
-
-    // Check if we have any advanced filters in URL
-    const hasAdvanced = status || amountMin || amountMax || startDate || endDate || accountsExclude.length > 0 || transfers !== 'hide'
-    if (hasAdvanced) {
-      setShowAdvancedFilters(true)
-    }
+    const accounts = accountSingle ? [accountSingle, ...accountsMulti] : accountsMulti
 
     setFilters({
       search,
@@ -164,7 +85,7 @@ function TransactionsContent() {
       endDate,
       transfers
     })
-    setSearchInput(search) // Sync search input with URL param
+    setSearchInput(search)
     setFiltersInitialized(true)
   }, [searchParamsString])
 
@@ -177,13 +98,36 @@ function TransactionsContent() {
     fetchLargeThreshold()
   }, [])
 
-  // Fetch the dynamic large transaction threshold from anomaly detection
+  // Fetch transactions when filters change
+  useEffect(() => {
+    if (filtersInitialized) {
+      fetchTransactions()
+    }
+  }, [filtersInitialized, filters])
+
+  // Set up intersection observer for infinite scroll
+  useEffect(() => {
+    if (observerRef.current) observerRef.current.disconnect()
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !loadingMore && !loading) {
+          loadMoreTransactions()
+        }
+      },
+      { threshold: 0.1 }
+    )
+
+    if (loadMoreRef.current) observerRef.current.observe(loadMoreRef.current)
+
+    return () => { if (observerRef.current) observerRef.current.disconnect() }
+  }, [hasMore, loadingMore, loading])
+
+  // Data fetching functions
   async function fetchLargeThreshold() {
     try {
       const now = new Date()
-      const year = now.getFullYear()
-      const month = now.getMonth() + 1
-      const res = await fetch(`/api/v1/reports/anomalies?year=${year}&month=${month}`)
+      const res = await fetch(`/api/v1/reports/anomalies?year=${now.getFullYear()}&month=${now.getMonth() + 1}`)
       if (res.ok) {
         const data = await res.json()
         if (data.summary?.large_threshold_amount) {
@@ -195,59 +139,34 @@ function TransactionsContent() {
     }
   }
 
-  // Fetch transactions when filters are initialized or change
-  useEffect(() => {
-    if (filtersInitialized) {
-      fetchTransactions()
-    }
-  }, [filtersInitialized, filters])
-
   async function fetchOccasionTags() {
     try {
       const res = await fetch('/api/v1/tags?namespace=occasion')
-      const data = await res.json()
-      setOccasionTags(data)
-    } catch (error) {
-      console.error('Error fetching occasion tags:', error)
-    }
+      setOccasionTags(await res.json())
+    } catch (error) { console.error('Error fetching occasion tags:', error) }
   }
 
   async function fetchBucketTags() {
     try {
       const res = await fetch('/api/v1/tags/buckets')
-      const data = await res.json()
-      setBucketTags(data)
-    } catch (error) {
-      console.error('Error fetching bucket tags:', error)
-    }
+      setBucketTags(await res.json())
+    } catch (error) { console.error('Error fetching bucket tags:', error) }
   }
 
   async function fetchAllTags() {
     try {
       const res = await fetch('/api/v1/tags')
-      const data = await res.json()
-      setAllTags(data)
-    } catch (error) {
-      console.error('Error fetching all tags:', error)
-    }
+      setAllTags(await res.json())
+    } catch (error) { console.error('Error fetching all tags:', error) }
   }
 
   async function fetchAccountTags() {
     try {
       const res = await fetch('/api/v1/tags?namespace=account')
-      const data = await res.json()
-      setAccountTags(data)
-    } catch (error) {
-      console.error('Error fetching account tags:', error)
-    }
+      setAccountTags(await res.json())
+    } catch (error) { console.error('Error fetching account tags:', error) }
   }
 
-  function getAccountDisplayName(accountSource: string): string {
-    const accountTag = accountTags.find(t => t.value === accountSource.toLowerCase().replace(/\s+/g, '-'))
-    return accountTag?.description || accountSource
-  }
-
-  // Build URL params from filters
   function buildFilterParams(): URLSearchParams {
     const params = new URLSearchParams()
     if (filters.search) params.append('search', filters.search)
@@ -260,40 +179,30 @@ function TransactionsContent() {
     if (filters.amountMax) params.append('amount_max', filters.amountMax)
     if (filters.startDate) params.append('start_date', filters.startDate)
     if (filters.endDate) params.append('end_date', filters.endDate)
-    // Transfer filter: hide=false, only=true, all=no param
     if (filters.transfers === 'hide') params.append('is_transfer', 'false')
     else if (filters.transfers === 'only') params.append('is_transfer', 'true')
     return params
   }
 
-  // Fetch total count
   async function fetchTotalCount() {
     try {
       const params = buildFilterParams()
       const res = await fetch(`/api/v1/transactions/count?${params.toString()}`)
       const data = await res.json()
       setTotalCount(data.count)
-    } catch (error) {
-      console.error('Error fetching count:', error)
-    }
+    } catch (error) { console.error('Error fetching count:', error) }
   }
 
-  // Fetch transactions with tags
   async function fetchTransactionsWithTags(txns: Transaction[]): Promise<Transaction[]> {
     return await Promise.all(
-      txns.map(async (txn: Transaction) => {
+      txns.map(async (txn) => {
         try {
           const tagsRes = await fetch(`/api/v1/transactions/${txn.id}/tags`)
           const tagsData = await tagsRes.json()
           const tags = tagsData.tags || []
           const bucketTag = tags.find((t: TransactionTag) => t.namespace === 'bucket')
           const accountTag = tags.find((t: TransactionTag) => t.namespace === 'account')
-          return {
-            ...txn,
-            tags,
-            bucket: bucketTag?.value || null,
-            account: accountTag?.value || null
-          }
+          return { ...txn, tags, bucket: bucketTag?.value || null, account: accountTag?.value || null }
         } catch {
           return { ...txn, tags: [], bucket: null, account: null }
         }
@@ -301,7 +210,6 @@ function TransactionsContent() {
     )
   }
 
-  // Initial fetch (resets list)
   async function fetchTransactions() {
     setLoading(true)
     try {
@@ -311,14 +219,11 @@ function TransactionsContent() {
 
       const res = await fetch(`/api/v1/transactions?${params.toString()}`)
       const data = await res.json()
-
       const transactionsWithTags = await fetchTransactionsWithTags(data)
 
       setTransactions(transactionsWithTags)
       setHasMore(data.length === PAGE_SIZE)
       setLoading(false)
-
-      // Also fetch total count
       fetchTotalCount()
     } catch (error) {
       console.error('Error fetching transactions:', error)
@@ -326,7 +231,6 @@ function TransactionsContent() {
     }
   }
 
-  // Load more transactions (append to list)
   const loadMoreTransactions = useCallback(async () => {
     if (loadingMore || !hasMore) return
 
@@ -343,7 +247,6 @@ function TransactionsContent() {
         const transactionsWithTags = await fetchTransactionsWithTags(data)
         setTransactions(prev => [...prev, ...transactionsWithTags])
       }
-
       setHasMore(data.length === PAGE_SIZE)
     } catch (error) {
       console.error('Error loading more transactions:', error)
@@ -352,101 +255,54 @@ function TransactionsContent() {
     }
   }, [loadingMore, hasMore, transactions.length, filters])
 
-  // Set up intersection observer for infinite scroll
-  useEffect(() => {
-    if (observerRef.current) {
-      observerRef.current.disconnect()
-    }
-
-    observerRef.current = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasMore && !loadingMore && !loading) {
-          loadMoreTransactions()
-        }
-      },
-      { threshold: 0.1 }
-    )
-
-    if (loadMoreRef.current) {
-      observerRef.current.observe(loadMoreRef.current)
-    }
-
-    return () => {
-      if (observerRef.current) {
-        observerRef.current.disconnect()
-      }
-    }
-  }, [hasMore, loadingMore, loading, loadMoreTransactions])
-
+  // Transaction handlers
   async function handleBucketChange(txnId: number, newBucket: string) {
     try {
       if (newBucket) {
-        // Add the new bucket tag (backend will replace existing bucket)
         await fetch(`/api/v1/transactions/${txnId}/tags`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ tag: `bucket:${newBucket}` })
         })
       } else {
-        // Find current bucket and remove it
         const txn = transactions.find(t => t.id === txnId)
         if (txn?.bucket) {
-          await fetch(`/api/v1/transactions/${txnId}/tags/bucket:${txn.bucket}`, {
-            method: 'DELETE'
-          })
+          await fetch(`/api/v1/transactions/${txnId}/tags/bucket:${txn.bucket}`, { method: 'DELETE' })
         }
       }
       fetchTransactions()
-    } catch (error) {
-      console.error('Error updating transaction bucket:', error)
-    }
+    } catch (error) { console.error('Error updating transaction bucket:', error) }
   }
 
   async function handleAccountChange(txnId: number, newAccountValue: string) {
     try {
-      // Find the account tag ID from the account tags
       const accountTag = accountTags.find(t => t.value === newAccountValue)
-      const newAccountTagId = accountTag?.id || null
-
-      // Update using PATCH endpoint
       await fetch(`/api/v1/transactions/${txnId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ account_tag_id: newAccountTagId })
+        body: JSON.stringify({ account_tag_id: accountTag?.id || null })
       })
 
-      // Also update the account tag through the tags system for consistency
       const txn = transactions.find(t => t.id === txnId)
-      // Remove existing account tag if any
       if (txn?.account) {
-        await fetch(`/api/v1/transactions/${txnId}/tags/account:${txn.account}`, {
-          method: 'DELETE'
-        }).catch(() => {}) // Ignore errors if tag doesn't exist
+        await fetch(`/api/v1/transactions/${txnId}/tags/account:${txn.account}`, { method: 'DELETE' }).catch(() => {})
       }
-      // Add new account tag if specified
       if (newAccountValue) {
         await fetch(`/api/v1/transactions/${txnId}/tags`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ tag: `account:${newAccountValue}` })
-        }).catch(() => {}) // Ignore errors if tag already exists
+        }).catch(() => {})
       }
-
       fetchTransactions()
-    } catch (error) {
-      console.error('Error updating transaction account:', error)
-    }
+    } catch (error) { console.error('Error updating transaction account:', error) }
   }
 
   async function handleRemoveTag(txnId: number, tagFull: string) {
     try {
-      await fetch(`/api/v1/transactions/${txnId}/tags/${tagFull}`, {
-        method: 'DELETE'
-      })
+      await fetch(`/api/v1/transactions/${txnId}/tags/${tagFull}`, { method: 'DELETE' })
       fetchTransactions()
-    } catch (error) {
-      console.error('Error removing tag:', error)
-    }
+    } catch (error) { console.error('Error removing tag:', error) }
   }
 
   async function handleAddTag(txnId: number, tagFull: string) {
@@ -457,134 +313,62 @@ function TransactionsContent() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ tag: tagFull })
       })
-      setAddingTagTo(null)
-      setNewTagValue('')
       fetchTransactions()
-    } catch (error) {
-      console.error('Error adding tag:', error)
-    }
+    } catch (error) { console.error('Error adding tag:', error) }
   }
 
-  // Get tags that aren't already on this transaction (excluding bucket and account namespaces)
-  function getAvailableTagsForTransaction(txn: Transaction): Tag[] {
-    const existingTags = new Set(txn.tags?.map(t => t.full) || [])
-    return allTags.filter(t =>
-      t.namespace !== 'bucket' &&
-      t.namespace !== 'account' &&
-      !existingTags.has(`${t.namespace}:${t.value}`)
-    )
-  }
-
-  // Bulk selection helpers
-  function toggleSelect(id: number) {
-    const newSet = new Set(selectedIds)
-    if (newSet.has(id)) {
-      newSet.delete(id)
-    } else {
-      newSet.add(id)
-    }
-    setSelectedIds(newSet)
-  }
-
-  function toggleSelectAll() {
-    if (selectedIds.size === transactions.length) {
-      setSelectedIds(new Set())
-    } else {
-      setSelectedIds(new Set(transactions.map(t => t.id)))
-    }
-  }
-
-  async function handleBulkApply() {
-    if (!bulkAction || !bulkValue || selectedIds.size === 0) return
-
-    setBulkLoading(true)
-    try {
-      const promises = Array.from(selectedIds).map(async (txnId) => {
-        await fetch(`/api/v1/transactions/${txnId}/tags`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ tag: bulkValue })
-        })
-      })
-
-      await Promise.all(promises)
-      setSelectedIds(new Set())
-      setBulkAction('')
-      setBulkValue('')
-      fetchTransactions()
-    } catch (error) {
-      console.error('Error applying bulk action:', error)
-    } finally {
-      setBulkLoading(false)
-    }
-  }
-
-  // Toggle expanded metadata view
-  function toggleExpand(id: number) {
-    const newSet = new Set(expandedIds)
-    if (newSet.has(id)) {
-      newSet.delete(id)
-    } else {
-      newSet.add(id)
-    }
-    setExpandedIds(newSet)
-  }
-
-  // Get bucket border color
-  function getBucketBorderColor(bucket: string | null | undefined): string {
-    if (!bucket) return 'border-l-gray-200'
-    return BUCKET_COLORS[bucket.toLowerCase()] || 'border-l-gray-400'
-  }
-
-  // Toggle transfer status
   async function handleToggleTransfer(txnId: number, currentIsTransfer: boolean) {
     try {
       await fetch('/api/v1/transfers/mark', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          transaction_ids: [txnId],
-          is_transfer: !currentIsTransfer
-        })
+        body: JSON.stringify({ transaction_ids: [txnId], is_transfer: !currentIsTransfer })
       })
       fetchTransactions()
-    } catch (error) {
-      console.error('Error toggling transfer status:', error)
-    }
+    } catch (error) { console.error('Error toggling transfer status:', error) }
   }
 
-  // Unlink a transfer pair
   async function handleUnlinkTransfer(txnId: number) {
     try {
-      await fetch(`/api/v1/transfers/${txnId}/link`, {
-        method: 'DELETE'
-      })
+      await fetch(`/api/v1/transfers/${txnId}/link`, { method: 'DELETE' })
       fetchTransactions()
-    } catch (error) {
-      console.error('Error unlinking transfer:', error)
-    }
+    } catch (error) { console.error('Error unlinking transfer:', error) }
   }
 
-  // Handle notes save
-  async function handleSaveNote(txnId: number) {
+  async function handleSaveNote(txnId: number, note: string) {
     try {
       await fetch(`/api/v1/transactions/${txnId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ notes: noteValue.trim() || null })
+        body: JSON.stringify({ notes: note || null })
       })
-      setEditingNoteId(null)
-      setNoteValue('')
       fetchTransactions()
-    } catch (error) {
-      console.error('Error saving note:', error)
-    }
+    } catch (error) { console.error('Error saving note:', error) }
   }
 
-  // Start editing note
-  function startEditNote(txn: Transaction) {
-    setEditingNoteId(txn.id)
-    setNoteValue(txn.notes || '')
+  async function handleBulkApplyTag(tagFull: string, ids: number[]) {
+    await Promise.all(ids.map(txnId =>
+      fetch(`/api/v1/transactions/${txnId}/tags`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tag: tagFull })
+      })
+    ))
+    bulkSelection.clearSelection()
+    fetchTransactions()
+  }
+
+  function toggleExpand(id: number) {
+    setExpandedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function handleSearch() {
+    setFilters({ ...filters, search: searchInput })
   }
 
   if (loading) {
@@ -620,589 +404,34 @@ function TransactionsContent() {
             </p>
           )}
         </div>
-        <Link
-          href="/import"
-          className="btn-primary"
-        >
+        <Link href="/import" className="btn-primary">
           Import CSV
         </Link>
       </div>
 
-      {/* Quick Filters */}
-      <div className="card p-4">
-        <div className="flex flex-wrap gap-4">
-          {/* Date Range Quick Filters */}
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs text-theme-muted font-medium uppercase tracking-wide">Date:</span>
-            <button
-              onClick={() => {
-                const now = new Date()
-                const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
-                const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
-                setFilters({
-                  ...filters,
-                  startDate: firstDay.toISOString().split('T')[0],
-                  endDate: lastDay.toISOString().split('T')[0]
-                })
-                setShowAdvancedFilters(true)
-              }}
-              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
-            >
-              This Month
-            </button>
-            <button
-              onClick={() => {
-                const now = new Date()
-                const firstDay = new Date(now.getFullYear(), now.getMonth() - 1, 1)
-                const lastDay = new Date(now.getFullYear(), now.getMonth(), 0)
-                setFilters({
-                  ...filters,
-                  startDate: firstDay.toISOString().split('T')[0],
-                  endDate: lastDay.toISOString().split('T')[0]
-                })
-                setShowAdvancedFilters(true)
-              }}
-              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
-              title={`${new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}`}
-            >
-              Last Month
-            </button>
-            <button
-              onClick={() => {
-                const now = new Date()
-                const firstDay = new Date(now.getFullYear(), 0, 1)
-                const lastDay = new Date(now.getFullYear(), 11, 31)
-                setFilters({
-                  ...filters,
-                  startDate: firstDay.toISOString().split('T')[0],
-                  endDate: lastDay.toISOString().split('T')[0]
-                })
-                setShowAdvancedFilters(true)
-              }}
-              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
-            >
-              This Year
-            </button>
-            <button
-              onClick={() => {
-                const now = new Date()
-                const firstDay = new Date(now.getFullYear(), 0, 1)
-                setFilters({
-                  ...filters,
-                  startDate: firstDay.toISOString().split('T')[0],
-                  endDate: now.toISOString().split('T')[0]
-                })
-                setShowAdvancedFilters(true)
-              }}
-              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
-            >
-              YTD
-            </button>
-            <button
-              onClick={() => {
-                const now = new Date()
-                const past = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000)
-                setFilters({
-                  ...filters,
-                  startDate: past.toISOString().split('T')[0],
-                  endDate: now.toISOString().split('T')[0]
-                })
-                setShowAdvancedFilters(true)
-              }}
-              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
-            >
-              Last 90 Days
-            </button>
-          </div>
+      <TransactionFiltersComponent
+        filters={filters}
+        searchInput={searchInput}
+        bucketTags={bucketTags}
+        occasionTags={occasionTags}
+        accountTags={accountTags}
+        largeThreshold={largeThreshold}
+        onFiltersChange={setFilters}
+        onSearchInputChange={setSearchInput}
+        onSearch={handleSearch}
+      />
 
-          <div className="h-6 w-px bg-theme hidden sm:block" />
-
-          {/* Insight Quick Filters */}
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs text-theme-muted font-medium uppercase tracking-wide">Quick:</span>
-            <button
-              onClick={() => {
-                const now = new Date()
-                const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
-                const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
-                // Use dynamic threshold or fall back to $100
-                const threshold = largeThreshold || 100
-                setFilters({
-                  ...filters,
-                  startDate: firstDay.toISOString().split('T')[0],
-                  endDate: lastDay.toISOString().split('T')[0],
-                  amountMin: '',
-                  amountMax: `-${threshold}`
-                })
-                setShowAdvancedFilters(true)
-              }}
-              className="px-3 py-1.5 text-xs rounded-full border border-orange-300 text-orange-700 bg-orange-50 hover:bg-orange-100 transition-colors dark:border-orange-700 dark:text-orange-300 dark:bg-orange-900/30 dark:hover:bg-orange-900/50"
-              title={largeThreshold ? `Large transactions this month (over $${largeThreshold} - 2σ above your average)` : 'Large transactions this month'}
-            >
-              ⚠️ Large{largeThreshold ? ` ($${largeThreshold}+)` : ''}
-            </button>
-            <button
-              onClick={() => {
-                const now = new Date()
-                const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
-                const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
-                setFilters({
-                  ...filters,
-                  startDate: firstDay.toISOString().split('T')[0],
-                  endDate: lastDay.toISOString().split('T')[0],
-                  amountMin: '',
-                  amountMax: '-50'
-                })
-                setShowAdvancedFilters(true)
-              }}
-              className="px-3 py-1.5 text-xs rounded-full border border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors dark:border-blue-700 dark:text-blue-300 dark:bg-blue-900/30 dark:hover:bg-blue-900/50"
-              title="Top spending this month (over $50)"
-            >
-              🏪 Top Spending
-            </button>
-            <button
-              onClick={() => {
-                setFilters({
-                  ...filters,
-                  amountMin: '',
-                  amountMax: '-100'
-                })
-                setShowAdvancedFilters(true)
-              }}
-              className="px-3 py-1.5 text-xs rounded-full border border-red-300 text-red-700 bg-red-50 hover:bg-red-100 transition-colors dark:border-red-700 dark:text-red-300 dark:bg-red-900/30 dark:hover:bg-red-900/50"
-              title="Transactions over $100"
-            >
-              💰 Large ($100+)
-            </button>
-            <button
-              onClick={() => {
-                setFilters({
-                  ...filters,
-                  status: 'unreconciled'
-                })
-                setShowAdvancedFilters(true)
-              }}
-              className="px-3 py-1.5 text-xs rounded-full border border-yellow-300 text-yellow-700 bg-yellow-50 hover:bg-yellow-100 transition-colors dark:border-yellow-700 dark:text-yellow-300 dark:bg-yellow-900/30 dark:hover:bg-yellow-900/50"
-              title="Transactions needing review"
-            >
-              📋 Unreconciled
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Filters */}
-      <div className="card p-4 space-y-4">
-        {/* Primary filters row */}
-        <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
-          <input
-            type="text"
-            placeholder="Search merchant or description..."
-            className="input"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                setFilters({ ...filters, search: searchInput })
-              }
-            }}
-          />
-          <select
-            className="input"
-            value={filters.bucket}
-            onChange={(e) => setFilters({ ...filters, bucket: e.target.value })}
-          >
-            <option value="">All Buckets</option>
-            {bucketTags.map((tag) => (
-              <option key={tag.id} value={tag.value}>
-                {tag.value.charAt(0).toUpperCase() + tag.value.slice(1)}
-              </option>
-            ))}
-          </select>
-          <select
-            className="input"
-            value={filters.occasion}
-            onChange={(e) => setFilters({ ...filters, occasion: e.target.value })}
-          >
-            <option value="">All Occasions</option>
-            {occasionTags.map((tag) => (
-              <option key={tag.id} value={tag.value}>
-                {tag.value.charAt(0).toUpperCase() + tag.value.slice(1).replace(/-/g, ' ')}
-              </option>
-            ))}
-          </select>
-          <div className="relative">
-            <button
-              type="button"
-              onClick={() => setShowAccountDropdown(!showAccountDropdown)}
-              className="w-full px-4 py-2 border border-theme rounded-md text-left flex justify-between items-center bg-theme-elevated"
-            >
-              <span className={filters.accounts.length > 0 || filters.accountsExclude.length > 0 ? 'text-theme' : 'text-theme-muted'}>
-                {filters.accounts.length > 0
-                  ? `${filters.accounts.length} selected`
-                  : filters.accountsExclude.length > 0
-                    ? `Excluding ${filters.accountsExclude.length}`
-                    : 'All Accounts'}
-              </span>
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-              </svg>
-            </button>
-            {showAccountDropdown && (
-              <div className="absolute z-20 mt-1 w-72 bg-theme-elevated border border-theme rounded-md shadow-lg max-h-64 overflow-y-auto">
-                <div className="p-2 border-b border-theme text-xs text-theme-muted">
-                  Click to include, Shift+Click to exclude
-                </div>
-                {accountTags.map((tag) => {
-                  const isIncluded = filters.accounts.includes(tag.value)
-                  const isExcluded = filters.accountsExclude.includes(tag.value)
-                  return (
-                    <div
-                      key={tag.id}
-                      onClick={(e) => {
-                        if (e.shiftKey) {
-                          // Toggle exclude
-                          if (isExcluded) {
-                            setFilters({
-                              ...filters,
-                              accountsExclude: filters.accountsExclude.filter(a => a !== tag.value)
-                            })
-                          } else {
-                            setFilters({
-                              ...filters,
-                              accounts: filters.accounts.filter(a => a !== tag.value),
-                              accountsExclude: [...filters.accountsExclude, tag.value]
-                            })
-                          }
-                        } else {
-                          // Toggle include
-                          if (isIncluded) {
-                            setFilters({
-                              ...filters,
-                              accounts: filters.accounts.filter(a => a !== tag.value)
-                            })
-                          } else {
-                            setFilters({
-                              ...filters,
-                              accounts: [...filters.accounts, tag.value],
-                              accountsExclude: filters.accountsExclude.filter(a => a !== tag.value)
-                            })
-                          }
-                        }
-                      }}
-                      className={`px-3 py-2 cursor-pointer flex items-center gap-2 text-sm ${
-                        isIncluded ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]' :
-                        isExcluded ? 'bg-negative text-negative' :
-                        'hover:bg-[var(--color-bg-hover)]'
-                      }`}
-                    >
-                      <span className={`w-4 h-4 border rounded flex items-center justify-center text-xs ${
-                        isIncluded ? 'bg-[var(--color-accent)] border-[var(--color-accent)] text-white' :
-                        isExcluded ? 'bg-[var(--color-negative)] border-[var(--color-negative)] text-white' :
-                        'border-theme'
-                      }`}>
-                        {isIncluded && '✓'}
-                        {isExcluded && '−'}
-                      </span>
-                      <span>{tag.description || tag.value}</span>
-                    </div>
-                  )
-                })}
-                {(filters.accounts.length > 0 || filters.accountsExclude.length > 0) && (
-                  <div className="p-2 border-t border-theme">
-                    <button
-                      onClick={() => setFilters({ ...filters, accounts: [], accountsExclude: [] })}
-                      className="text-xs text-theme-muted hover:text-theme"
-                    >
-                      Clear selection
-                    </button>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setFilters({ ...filters, search: searchInput })}
-              className="flex-1 btn-primary"
-            >
-              Search
-            </button>
-            <button
-              onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
-              className={`px-3 py-2 border border-theme rounded-md ${showAdvancedFilters ? 'bg-[var(--color-bg-hover)]' : ''}`}
-              title="Advanced filters"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-              </svg>
-            </button>
-          </div>
-        </div>
-
-        {/* Advanced filters (collapsible) */}
-        {showAdvancedFilters && (
-          <div className="pt-4 border-t border-theme">
-            <div className="grid grid-cols-1 md:grid-cols-6 gap-4">
-              <select
-                className="input"
-                value={filters.status}
-                onChange={(e) => setFilters({ ...filters, status: e.target.value })}
-              >
-                <option value="">All Status</option>
-                <option value="unreconciled">Unreconciled</option>
-                <option value="matched">Matched</option>
-                <option value="manually_entered">Manually Entered</option>
-                <option value="ignored">Ignored</option>
-              </select>
-              <select
-                className="input"
-                value={filters.transfers}
-                onChange={(e) => setFilters({ ...filters, transfers: e.target.value as 'all' | 'hide' | 'only' })}
-                title="Filter internal transfers (CC payments, bank transfers)"
-              >
-                <option value="hide">Hide Transfers</option>
-                <option value="all">All Transactions</option>
-                <option value="only">Transfers Only</option>
-              </select>
-              <div className="flex gap-2 items-center">
-                <input
-                  type="number"
-                  placeholder="Min $"
-                  className="input w-full"
-                  value={filters.amountMin}
-                  onChange={(e) => setFilters({ ...filters, amountMin: e.target.value })}
-                />
-                <span className="text-theme-muted">–</span>
-                <input
-                  type="number"
-                  placeholder="Max $"
-                  className="input w-full"
-                  value={filters.amountMax}
-                  onChange={(e) => setFilters({ ...filters, amountMax: e.target.value })}
-                />
-              </div>
-              <input
-                type="date"
-                className="input"
-                value={filters.startDate}
-                onChange={(e) => setFilters({ ...filters, startDate: e.target.value })}
-                title="Start date"
-              />
-              <input
-                type="date"
-                className="input"
-                value={filters.endDate}
-                onChange={(e) => setFilters({ ...filters, endDate: e.target.value })}
-                title="End date"
-              />
-              <button
-                onClick={() => {
-                  setSearchInput('')
-                  setFilters({
-                    search: '',
-                    bucket: '',
-                    occasion: '',
-                    accounts: [],
-                    accountsExclude: [],
-                    status: '',
-                    amountMin: '',
-                    amountMax: '',
-                    startDate: '',
-                    endDate: '',
-                    transfers: 'hide'
-                  })
-                  setShowAccountDropdown(false)
-                }}
-                className="px-4 py-2 text-theme-muted border border-theme rounded-md hover:bg-[var(--color-bg-hover)]"
-              >
-                Clear All
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Active filters pills */}
-        {(filters.bucket || filters.occasion || filters.accounts.length > 0 || filters.accountsExclude.length > 0 || filters.status || filters.amountMin || filters.amountMax || filters.startDate || filters.endDate || filters.transfers !== 'hide') && (
-          <div className="flex flex-wrap gap-2 pt-2">
-            {filters.bucket && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-800 rounded-full text-xs">
-                Bucket: {filters.bucket}
-                <button onClick={() => setFilters({ ...filters, bucket: '' })} className="hover:text-green-900">×</button>
-              </span>
-            )}
-            {filters.occasion && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 bg-purple-100 text-purple-800 rounded-full text-xs">
-                Occasion: {filters.occasion.replace(/-/g, ' ')}
-                <button onClick={() => setFilters({ ...filters, occasion: '' })} className="hover:text-purple-900">×</button>
-              </span>
-            )}
-            {filters.accounts.map(acc => (
-              <span key={`inc-${acc}`} className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs">
-                Account: {accountTags.find(t => t.value === acc)?.description || acc}
-                <button onClick={() => setFilters({ ...filters, accounts: filters.accounts.filter(a => a !== acc) })} className="hover:text-blue-900">×</button>
-              </span>
-            ))}
-            {filters.accountsExclude.map(acc => (
-              <span key={`exc-${acc}`} className="inline-flex items-center gap-1 px-2 py-1 bg-red-100 text-red-800 rounded-full text-xs">
-                NOT: {accountTags.find(t => t.value === acc)?.description || acc}
-                <button onClick={() => setFilters({ ...filters, accountsExclude: filters.accountsExclude.filter(a => a !== acc) })} className="hover:text-red-900">×</button>
-              </span>
-            ))}
-            {filters.status && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 bg-yellow-100 text-yellow-800 rounded-full text-xs">
-                Status: {filters.status}
-                <button onClick={() => setFilters({ ...filters, status: '' })} className="hover:text-yellow-900">×</button>
-              </span>
-            )}
-            {(filters.amountMin || filters.amountMax) && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 bg-orange-100 text-orange-800 rounded-full text-xs">
-                Amount: {filters.amountMin || '∞'} – {filters.amountMax || '∞'}
-                <button onClick={() => setFilters({ ...filters, amountMin: '', amountMax: '' })} className="hover:text-orange-900">×</button>
-              </span>
-            )}
-            {(filters.startDate || filters.endDate) && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 text-gray-800 rounded-full text-xs">
-                Date: {filters.startDate || '...'} – {filters.endDate || '...'}
-                <button onClick={() => setFilters({ ...filters, startDate: '', endDate: '' })} className="hover:text-gray-900">×</button>
-              </span>
-            )}
-            {filters.transfers !== 'hide' && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs">
-                {filters.transfers === 'all' ? 'Including Transfers' : 'Transfers Only'}
-                <button onClick={() => setFilters({ ...filters, transfers: 'hide' })} className="hover:text-blue-900">×</button>
-              </span>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Bulk Actions Bar - Sticky when items selected */}
-      <div className={`rounded-lg shadow p-4 transition-all duration-200 ${
-        selectedIds.size > 0
-          ? 'bg-[var(--color-accent)]/10 border-2 border-[var(--color-accent)]/30 sticky top-0 z-10'
-          : 'card'
-      }`}>
-        <div className="flex flex-wrap items-center gap-4">
-          <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={selectedIds.size === transactions.length && transactions.length > 0}
-              ref={el => {
-                if (el) {
-                  el.indeterminate = selectedIds.size > 0 && selectedIds.size < transactions.length
-                }
-              }}
-              onChange={toggleSelectAll}
-              className="w-4 h-4 rounded"
-            />
-            <span className={`text-sm font-medium ${selectedIds.size > 0 ? 'text-[var(--color-accent)]' : 'text-theme-muted'}`}>
-              {selectedIds.size > 0
-                ? `${selectedIds.size} of ${totalCount.toLocaleString()} selected`
-                : `Select all (${transactions.length} loaded)`}
-            </span>
-          </div>
-
-          {selectedIds.size > 0 && (
-            <>
-              <div className="h-6 w-px bg-[var(--color-accent)]/30" />
-
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-[var(--color-accent)]">Assign:</span>
-                <select
-                  value={bulkAction}
-                  onChange={(e) => {
-                    setBulkAction(e.target.value)
-                    setBulkValue('')
-                  }}
-                  className="px-3 py-1.5 border border-[var(--color-accent)]/30 rounded-md text-sm bg-theme-elevated focus:ring-2 focus:ring-[var(--color-accent)]"
-                >
-                  <option value="">Choose type...</option>
-                  <option value="bucket">Bucket</option>
-                  <option value="occasion">Occasion</option>
-                  <option value="account">Account</option>
-                </select>
-
-                {bulkAction === 'bucket' && (
-                  <select
-                    value={bulkValue}
-                    onChange={(e) => setBulkValue(e.target.value)}
-                    className="px-3 py-1.5 border border-[var(--color-accent)]/30 rounded-md text-sm bg-theme-elevated focus:ring-2 focus:ring-[var(--color-accent)]"
-                  >
-                    <option value="">Select bucket...</option>
-                    {bucketTags.map((tag) => (
-                      <option key={tag.id} value={`bucket:${tag.value}`}>
-                        {tag.value.charAt(0).toUpperCase() + tag.value.slice(1)}
-                      </option>
-                    ))}
-                  </select>
-                )}
-
-                {bulkAction === 'occasion' && (
-                  <select
-                    value={bulkValue}
-                    onChange={(e) => setBulkValue(e.target.value)}
-                    className="px-3 py-1.5 border border-[var(--color-accent)]/30 rounded-md text-sm bg-theme-elevated focus:ring-2 focus:ring-[var(--color-accent)]"
-                  >
-                    <option value="">Select occasion...</option>
-                    {occasionTags.map((tag) => (
-                      <option key={tag.id} value={`occasion:${tag.value}`}>
-                        {tag.value.charAt(0).toUpperCase() + tag.value.slice(1).replace(/-/g, ' ')}
-                      </option>
-                    ))}
-                  </select>
-                )}
-
-                {bulkAction === 'account' && (
-                  <select
-                    value={bulkValue}
-                    onChange={(e) => setBulkValue(e.target.value)}
-                    className="px-3 py-1.5 border border-[var(--color-accent)]/30 rounded-md text-sm bg-theme-elevated focus:ring-2 focus:ring-[var(--color-accent)]"
-                  >
-                    <option value="">Select account...</option>
-                    {accountTags.map((tag) => (
-                      <option key={tag.id} value={`account:${tag.value}`}>
-                        {tag.description || tag.value}
-                      </option>
-                    ))}
-                  </select>
-                )}
-              </div>
-
-              {bulkValue && (
-                <button
-                  onClick={handleBulkApply}
-                  disabled={bulkLoading}
-                  className="btn-primary text-sm disabled:opacity-50"
-                >
-                  {bulkLoading ? (
-                    <span className="flex items-center gap-2">
-                      <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                      </svg>
-                      Applying...
-                    </span>
-                  ) : (
-                    `Apply to ${selectedIds.size}`
-                  )}
-                </button>
-              )}
-
-              <button
-                onClick={() => {
-                  setSelectedIds(new Set())
-                  setBulkAction('')
-                  setBulkValue('')
-                }}
-                className="ml-auto text-sm text-[var(--color-accent)] hover:opacity-80 font-medium"
-              >
-                Clear selection
-              </button>
-            </>
-          )}
-        </div>
-      </div>
+      <BulkActionsBar
+        selectedIds={bulkSelection.selectedIds}
+        transactions={transactions}
+        totalCount={totalCount}
+        bucketTags={bucketTags}
+        occasionTags={occasionTags}
+        accountTags={accountTags}
+        onToggleAll={() => bulkSelection.toggleAll(transactions)}
+        onClearSelection={bulkSelection.clearSelection}
+        onApplyTag={handleBulkApplyTag}
+      />
 
       {/* Transactions List */}
       <div className="card">
@@ -1212,407 +441,25 @@ function TransactionsContent() {
           </div>
         ) : (
           transactions.map((txn) => (
-            <div
+            <TransactionRow
               key={txn.id}
-              className={`
-                border-l-4 ${getBucketBorderColor(txn.bucket)}
-                border-b border-theme
-                transition-all duration-150 ease-in-out
-                text-sm
-                ${selectedIds.has(txn.id)
-                  ? 'bg-[var(--color-accent)]/10'
-                  : 'hover:bg-[var(--color-bg-hover)]'
-                }
-              `}
-            >
-              {/* DESKTOP: Compact table-style grid */}
-              <div className="hidden md:block px-4 py-2">
-                {/* Top row: checkbox, date, merchant, bucket, account, amount */}
-                {/* Using 50% split - left half for checkbox/date/merchant, right half for dropdowns/amount */}
-                <div className="flex items-start gap-3">
-                  {/* Left side: checkbox, date, merchant (about 45%) */}
-                  <div className="flex items-start gap-3 w-[45%] min-w-0">
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.has(txn.id)}
-                      onChange={() => toggleSelect(txn.id)}
-                      className="w-4 h-4 rounded mt-0.5 flex-shrink-0"
-                    />
-                    <span className="text-xs text-theme-muted pt-0.5 w-20 flex-shrink-0">
-                      {format(new Date(txn.date), 'MM/dd/yyyy')}
-                    </span>
-                    <p className="font-medium text-theme truncate min-w-0">
-                      {txn.merchant || 'Unknown'}
-                    </p>
-                  </div>
-
-                  {/* Right side: bucket, account, amount (about 55%) - aligned with tags below */}
-                  <div className="flex items-start gap-3 flex-1">
-                    <select
-                      value={txn.bucket || ''}
-                      onChange={(e) => handleBucketChange(txn.id, e.target.value)}
-                      className="h-7 w-32 rounded border border-theme px-2 text-xs bg-theme-elevated"
-                    >
-                      <option value="">No Bucket</option>
-                      {bucketTags.map((tag) => (
-                        <option key={tag.id} value={tag.value}>
-                          {tag.value.charAt(0).toUpperCase() + tag.value.slice(1)}
-                        </option>
-                      ))}
-                    </select>
-
-                    <select
-                      value={txn.account || ''}
-                      onChange={(e) => handleAccountChange(txn.id, e.target.value)}
-                      className="h-7 w-40 rounded border border-theme px-2 text-xs bg-theme-elevated"
-                    >
-                      <option value="">No Account</option>
-                      {accountTags.map((tag) => (
-                        <option key={tag.id} value={tag.value}>
-                          {tag.description || tag.value}
-                        </option>
-                      ))}
-                    </select>
-
-                    <div className="flex items-center gap-1 ml-auto flex-shrink-0">
-                      {txn.is_transfer && (
-                        <span className="px-1.5 py-0.5 text-xs rounded bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300" title="Internal transfer - excluded from spending">
-                          Transfer
-                        </span>
-                      )}
-                      <span className={`font-semibold text-sm ${txn.is_transfer ? 'text-theme-muted' : txn.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
-                        {formatCurrency(txn.amount, true)}
-                      </span>
-                      <button
-                        onClick={() => toggleExpand(txn.id)}
-                        className="text-theme-muted hover:text-theme p-0.5"
-                        title={expandedIds.has(txn.id) ? 'Collapse' : 'Expand'}
-                      >
-                        <svg
-                          className={`w-4 h-4 transition-transform duration-200 ${expandedIds.has(txn.id) ? 'rotate-180' : ''}`}
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Second row: description + add tag button | tags container */}
-                <div className="flex items-center gap-3 mt-1">
-                  {/* Left side: spacer + description + add tag button (right-justified) */}
-                  <div className="flex items-center gap-3 w-[45%] min-w-0">
-                    <div className="w-4 flex-shrink-0"></div>
-                    <div className="w-20 flex-shrink-0"></div>
-                    <p className="text-xs text-theme-muted truncate min-w-0 flex-1">
-                      {txn.description !== txn.merchant ? txn.description : ''}
-                    </p>
-                    {/* Add tag button - right justified in left column */}
-                    {addingTagTo === txn.id ? (
-                      <div className="inline-flex items-center gap-1 flex-shrink-0">
-                        <select
-                          value=""
-                          onChange={(e) => {
-                            if (e.target.value) {
-                              handleAddTag(txn.id, e.target.value)
-                            }
-                          }}
-                          className="text-xs border rounded px-1 py-0.5 bg-theme-elevated"
-                          autoFocus
-                          onBlur={() => { setAddingTagTo(null); setNewTagValue('') }}
-                        >
-                          <option value="">Select...</option>
-                          {getAvailableTagsForTransaction(txn).map((tag) => (
-                            <option key={tag.id} value={`${tag.namespace}:${tag.value}`}>
-                              {tag.namespace}:{tag.value}
-                            </option>
-                          ))}
-                        </select>
-                        <button
-                          onClick={() => { setAddingTagTo(null); setNewTagValue('') }}
-                          className="text-xs text-theme-muted hover:text-theme"
-                        >
-                          ×
-                        </button>
-                      </div>
-                    ) : (
-                      <button
-                        onClick={() => setAddingTagTo(txn.id)}
-                        className="text-xs text-blue-500 hover:text-blue-700 whitespace-nowrap flex-shrink-0"
-                        title="Add tag"
-                      >
-                        + tag
-                      </button>
-                    )}
-                  </div>
-
-                  {/* Right side: tags area (aligned with dropdowns) */}
-                  <div className="flex items-center flex-wrap gap-1.5 px-2 py-1 rounded bg-theme-subtle min-h-[1.75rem] flex-1">
-                    {/* Notes indicator */}
-                    {txn.notes && !expandedIds.has(txn.id) && (
-                      <span className="inline-flex items-center gap-0.5 text-[11px] text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded-full" title={txn.notes}>
-                        <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-                          <path fillRule="evenodd" d="M18 13V5a2 2 0 00-2-2H4a2 2 0 00-2 2v8a2 2 0 002 2h3l3 3 3-3h3a2 2 0 002-2zM5 7a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1zm1 3a1 1 0 100 2h3a1 1 0 100-2H6z" clipRule="evenodd" />
-                        </svg>
-                      </span>
-                    )}
-
-                    {/* Non-bucket, non-account tags as chips */}
-                    {txn.tags?.filter(t => t.namespace !== 'bucket' && t.namespace !== 'account').map((tag) => {
-                      // Look up the full tag to get description
-                      const fullTag = allTags.find(t => t.namespace === tag.namespace && t.value === tag.value)
-                      const displayText = fullTag?.description || tag.value.replace(/-/g, ' ')
-                      return (
-                        <span
-                          key={tag.full}
-                          className="inline-flex items-center gap-0.5 rounded-full bg-purple-100 px-2 py-0.5 text-[11px] text-purple-700"
-                          title={`${tag.namespace}:${tag.value}`}
-                        >
-                          {displayText}
-                          <button
-                            onClick={() => handleRemoveTag(txn.id, tag.full)}
-                            className="hover:text-purple-900 ml-0.5"
-                          >
-                            ×
-                          </button>
-                        </span>
-                      )
-                    })}
-
-                    {/* Empty state when no tags */}
-                    {(!txn.tags || txn.tags.filter(t => t.namespace !== 'bucket' && t.namespace !== 'account').length === 0) && !txn.notes && (
-                      <span className="text-[11px] text-theme-muted/40">—</span>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* MOBILE: Card-style layout */}
-              <div className="md:hidden px-4 py-3">
-                <div className="flex items-start gap-3">
-                  <input
-                    type="checkbox"
-                    checked={selectedIds.has(txn.id)}
-                    onChange={() => toggleSelect(txn.id)}
-                    className="w-4 h-4 mt-1 rounded"
-                  />
-
-                  <div className="flex-1 min-w-0">
-                    <div className="flex justify-between items-start gap-2">
-                      <div className="min-w-0 flex-1">
-                        <p className="font-medium text-theme truncate">
-                          {txn.merchant || 'Unknown'}
-                        </p>
-                        <p className="text-xs text-theme-muted">
-                          {format(new Date(txn.date), 'MM/dd/yyyy')}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-1">
-                        {txn.is_transfer && (
-                          <span className="px-1 py-0.5 text-xs rounded bg-blue-100 text-blue-700" title="Transfer">
-                            T
-                          </span>
-                        )}
-                        <span className={`font-semibold ${txn.is_transfer ? 'text-theme-muted' : txn.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
-                          {formatCurrency(txn.amount, true)}
-                        </span>
-                        <button
-                          onClick={() => toggleExpand(txn.id)}
-                          className="text-theme-muted hover:text-theme p-0.5"
-                        >
-                          <svg
-                            className={`w-4 h-4 transition-transform duration-200 ${expandedIds.has(txn.id) ? 'rotate-180' : ''}`}
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                          </svg>
-                        </button>
-                      </div>
-                    </div>
-
-                    {/* Mobile controls row */}
-                    <div className="flex flex-wrap items-center gap-2 mt-2">
-                      <select
-                        value={txn.bucket || ''}
-                        onChange={(e) => handleBucketChange(txn.id, e.target.value)}
-                        className="h-7 rounded border border-theme px-2 text-xs bg-theme-elevated"
-                      >
-                        <option value="">Bucket</option>
-                        {bucketTags.map((tag) => (
-                          <option key={tag.id} value={tag.value}>
-                            {tag.value.charAt(0).toUpperCase() + tag.value.slice(1)}
-                          </option>
-                        ))}
-                      </select>
-
-                      <select
-                        value={txn.account || ''}
-                        onChange={(e) => handleAccountChange(txn.id, e.target.value)}
-                        className="h-7 rounded border border-theme px-2 text-xs bg-theme-elevated"
-                      >
-                        <option value="">Account</option>
-                        {accountTags.map((tag) => (
-                          <option key={tag.id} value={tag.value}>
-                            {tag.description || tag.value}
-                          </option>
-                        ))}
-                      </select>
-
-                      {/* Tags */}
-                      {txn.tags?.filter(t => t.namespace !== 'bucket' && t.namespace !== 'account').map((tag) => {
-                        const fullTag = allTags.find(t => t.namespace === tag.namespace && t.value === tag.value)
-                        const displayText = fullTag?.description || tag.value.replace(/-/g, ' ')
-                        return (
-                          <span
-                            key={tag.full}
-                            className="inline-flex items-center gap-0.5 rounded-full bg-purple-100 px-2 py-0.5 text-[11px] text-purple-700"
-                          >
-                            {displayText}
-                            <button onClick={() => handleRemoveTag(txn.id, tag.full)} className="hover:text-purple-900">×</button>
-                          </span>
-                        )
-                      })}
-
-                      <button
-                        onClick={() => setAddingTagTo(txn.id)}
-                        className="text-xs text-blue-500 hover:text-blue-700"
-                      >
-                        + tag
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* EXPANDED METADATA SECTION */}
-              {expandedIds.has(txn.id) && (
-                <div className="px-4 pb-4 pt-2 md:pl-12 border-t border-theme bg-[var(--color-bg-hover)]">
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-                    {/* Left column: metadata */}
-                    <div className="space-y-2">
-                      <div className="flex gap-2">
-                        <span className="text-theme-muted w-24">Status:</span>
-                        <span className={`px-2 py-0.5 rounded text-xs font-medium ${
-                          txn.reconciliation_status === 'matched' ? 'bg-green-100 text-green-800' :
-                          txn.reconciliation_status === 'ignored' ? 'bg-gray-100 text-gray-600' :
-                          'bg-yellow-100 text-yellow-800'
-                        }`}>
-                          {txn.reconciliation_status}
-                        </span>
-                      </div>
-                      <div className="flex gap-2">
-                        <span className="text-theme-muted w-24">Description:</span>
-                        <span className="text-theme">{txn.description}</span>
-                      </div>
-                      {txn.account_source && (
-                        <div className="flex gap-2">
-                          <span className="text-theme-muted w-24">Source:</span>
-                          <span className="text-theme-muted text-xs">{txn.account_source}</span>
-                        </div>
-                      )}
-                      {txn.category && (
-                        <div className="flex gap-2">
-                          <span className="text-theme-muted w-24">Legacy cat:</span>
-                          <span className="text-theme-muted italic">{txn.category}</span>
-                        </div>
-                      )}
-                      <div className="flex gap-2">
-                        <span className="text-theme-muted w-24">ID:</span>
-                        <span className="text-theme-muted font-mono text-xs">{txn.id}</span>
-                      </div>
-                      {/* Transfer controls */}
-                      <div className="flex gap-2 items-center">
-                        <span className="text-theme-muted w-24">Transfer:</span>
-                        <button
-                          onClick={() => handleToggleTransfer(txn.id, txn.is_transfer || false)}
-                          className={`px-2 py-0.5 rounded text-xs font-medium transition-colors ${
-                            txn.is_transfer
-                              ? 'bg-blue-100 text-blue-800 hover:bg-blue-200'
-                              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                          }`}
-                          title={txn.is_transfer ? 'Click to unmark as transfer' : 'Click to mark as transfer'}
-                        >
-                          {txn.is_transfer ? '✓ Marked as Transfer' : 'Not a Transfer'}
-                        </button>
-                      </div>
-                      {txn.linked_transaction_id && (
-                        <div className="flex gap-2 items-center">
-                          <span className="text-theme-muted w-24">Linked to:</span>
-                          <span className="text-theme font-mono text-xs">#{txn.linked_transaction_id}</span>
-                          <button
-                            onClick={() => handleUnlinkTransfer(txn.id)}
-                            className="text-xs text-red-500 hover:text-red-700"
-                            title="Unlink this transfer pair"
-                          >
-                            Unlink
-                          </button>
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Middle column: notes */}
-                    <div>
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-theme-muted">Notes:</span>
-                        {editingNoteId !== txn.id && (
-                          <button
-                            onClick={() => startEditNote(txn)}
-                            className="text-xs text-blue-500 hover:text-blue-700"
-                          >
-                            {txn.notes ? 'Edit' : 'Add note'}
-                          </button>
-                        )}
-                      </div>
-                      {editingNoteId === txn.id ? (
-                        <div className="space-y-2">
-                          <textarea
-                            value={noteValue}
-                            onChange={(e) => setNoteValue(e.target.value)}
-                            className="w-full px-2 py-1 text-sm border border-theme rounded resize-none bg-theme-elevated"
-                            rows={2}
-                            placeholder="Add a note..."
-                            autoFocus
-                          />
-                          <div className="flex gap-2">
-                            <button
-                              onClick={() => handleSaveNote(txn.id)}
-                              className="px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700"
-                            >
-                              Save
-                            </button>
-                            <button
-                              onClick={() => { setEditingNoteId(null); setNoteValue('') }}
-                              className="px-2 py-1 text-xs text-theme-muted hover:text-theme"
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </div>
-                      ) : (
-                        <p className={`text-sm ${txn.notes ? 'text-theme' : 'text-theme-muted italic'}`}>
-                          {txn.notes || 'No notes'}
-                        </p>
-                      )}
-                    </div>
-
-                    {/* Right column: splits */}
-                    <div className="border-l border-theme pl-4">
-                      <SplitTransaction
-                        transactionId={txn.id}
-                        transactionAmount={txn.amount}
-                        bucketTags={bucketTags}
-                        onSplitsChanged={fetchTransactions}
-                      />
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
+              transaction={txn}
+              isSelected={bulkSelection.isSelected(txn.id)}
+              isExpanded={expandedIds.has(txn.id)}
+              bucketTags={bucketTags}
+              accountTags={accountTags}
+              allTags={allTags}
+              onToggleSelect={() => bulkSelection.toggle(txn.id)}
+              onToggleExpand={() => toggleExpand(txn.id)}
+              onBucketChange={handleBucketChange}
+              onAccountChange={handleAccountChange}
+              onRemoveTag={handleRemoveTag}
+              onAddTag={handleAddTag}
+              onToggleTransfer={handleToggleTransfer}
+              onUnlinkTransfer={handleUnlinkTransfer}
+              onSaveNote={handleSaveNote}
+              onTransactionsChanged={fetchTransactions}
+            />
           ))
         )}
 

--- a/frontend/src/components/transactions/BulkActionsBar.test.tsx
+++ b/frontend/src/components/transactions/BulkActionsBar.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import BulkActionsBar from './BulkActionsBar'
+import { Transaction, Tag } from '@/types/transactions'
+
+const mockTransactions: Transaction[] = [
+  { id: 1, date: '2024-12-01', amount: -50, description: 'Test 1', merchant: 'Store', account_source: 'checking', account_tag_id: null, category: null, reconciliation_status: 'unreconciled' },
+  { id: 2, date: '2024-12-02', amount: -75, description: 'Test 2', merchant: 'Shop', account_source: 'checking', account_tag_id: null, category: null, reconciliation_status: 'unreconciled' },
+]
+
+const mockBucketTags: Tag[] = [
+  { id: 1, namespace: 'bucket', value: 'groceries', description: 'Food shopping' },
+  { id: 2, namespace: 'bucket', value: 'dining', description: 'Restaurants' },
+]
+
+const mockOccasionTags: Tag[] = [
+  { id: 3, namespace: 'occasion', value: 'vacation-2024', description: 'Summer vacation' },
+]
+
+const mockAccountTags: Tag[] = [
+  { id: 4, namespace: 'account', value: 'checking', description: 'Main Checking' },
+]
+
+describe('BulkActionsBar', () => {
+  const defaultProps = {
+    selectedIds: new Set<number>(),
+    transactions: mockTransactions,
+    totalCount: 100,
+    bucketTags: mockBucketTags,
+    occasionTags: mockOccasionTags,
+    accountTags: mockAccountTags,
+    onToggleAll: vi.fn(),
+    onClearSelection: vi.fn(),
+    onApplyTag: vi.fn().mockResolvedValue(undefined),
+  }
+
+  it('renders with no selection', () => {
+    render(<BulkActionsBar {...defaultProps} />)
+    expect(screen.getByTestId('bulk-actions-bar')).toBeInTheDocument()
+    expect(screen.getByText('Select all (2 loaded)')).toBeInTheDocument()
+  })
+
+  it('shows selection count when items selected', () => {
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1, 2])} />)
+    expect(screen.getByText('2 of 100 selected')).toBeInTheDocument()
+  })
+
+  it('shows clear selection button when items selected', () => {
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1])} />)
+    expect(screen.getByTestId('clear-selection-btn')).toBeInTheDocument()
+  })
+
+  it('calls onClearSelection when clear button clicked', async () => {
+    const user = userEvent.setup()
+    const onClearSelection = vi.fn()
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1])} onClearSelection={onClearSelection} />)
+
+    await user.click(screen.getByTestId('clear-selection-btn'))
+    expect(onClearSelection).toHaveBeenCalled()
+  })
+
+  it('calls onToggleAll when select all checkbox clicked', async () => {
+    const user = userEvent.setup()
+    const onToggleAll = vi.fn()
+    render(<BulkActionsBar {...defaultProps} onToggleAll={onToggleAll} />)
+
+    await user.click(screen.getByTestId('select-all-checkbox'))
+    expect(onToggleAll).toHaveBeenCalled()
+  })
+
+  it('shows bulk action type dropdown when items selected', () => {
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1])} />)
+    expect(screen.getByTestId('bulk-action-type')).toBeInTheDocument()
+  })
+
+  it('shows bucket dropdown when bucket action selected', async () => {
+    const user = userEvent.setup()
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1])} />)
+
+    await user.selectOptions(screen.getByTestId('bulk-action-type'), 'bucket')
+    expect(screen.getByTestId('bulk-bucket-select')).toBeInTheDocument()
+  })
+
+  it('shows occasion dropdown when occasion action selected', async () => {
+    const user = userEvent.setup()
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1])} />)
+
+    await user.selectOptions(screen.getByTestId('bulk-action-type'), 'occasion')
+    expect(screen.getByTestId('bulk-occasion-select')).toBeInTheDocument()
+  })
+
+  it('shows account dropdown when account action selected', async () => {
+    const user = userEvent.setup()
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1])} />)
+
+    await user.selectOptions(screen.getByTestId('bulk-action-type'), 'account')
+    expect(screen.getByTestId('bulk-account-select')).toBeInTheDocument()
+  })
+
+  it('shows apply button when action and value selected', async () => {
+    const user = userEvent.setup()
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1])} />)
+
+    await user.selectOptions(screen.getByTestId('bulk-action-type'), 'bucket')
+    await user.selectOptions(screen.getByTestId('bulk-bucket-select'), 'bucket:groceries')
+
+    expect(screen.getByTestId('bulk-apply-btn')).toBeInTheDocument()
+    expect(screen.getByText('Apply to 1')).toBeInTheDocument()
+  })
+
+  it('calls onApplyTag when apply button clicked', async () => {
+    const user = userEvent.setup()
+    const onApplyTag = vi.fn().mockResolvedValue(undefined)
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1, 2])} onApplyTag={onApplyTag} />)
+
+    await user.selectOptions(screen.getByTestId('bulk-action-type'), 'bucket')
+    await user.selectOptions(screen.getByTestId('bulk-bucket-select'), 'bucket:groceries')
+    await user.click(screen.getByTestId('bulk-apply-btn'))
+
+    await waitFor(() => {
+      expect(onApplyTag).toHaveBeenCalledWith('bucket:groceries', [1, 2])
+    })
+  })
+
+  it('checkbox is checked when all transactions selected', () => {
+    render(<BulkActionsBar {...defaultProps} selectedIds={new Set([1, 2])} />)
+    const checkbox = screen.getByTestId('select-all-checkbox') as HTMLInputElement
+    expect(checkbox.checked).toBe(true)
+  })
+})

--- a/frontend/src/components/transactions/BulkActionsBar.tsx
+++ b/frontend/src/components/transactions/BulkActionsBar.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useState, useRef, useEffect } from 'react'
+import { Tag, Transaction } from '@/types/transactions'
+
+interface BulkActionsBarProps {
+  selectedIds: Set<number>
+  transactions: Transaction[]
+  totalCount: number
+  bucketTags: Tag[]
+  occasionTags: Tag[]
+  accountTags: Tag[]
+  onToggleAll: () => void
+  onClearSelection: () => void
+  onApplyTag: (tagFull: string, ids: number[]) => Promise<void>
+}
+
+export default function BulkActionsBar({
+  selectedIds,
+  transactions,
+  totalCount,
+  bucketTags,
+  occasionTags,
+  accountTags,
+  onToggleAll,
+  onClearSelection,
+  onApplyTag,
+}: BulkActionsBarProps) {
+  const [bulkAction, setBulkAction] = useState('')
+  const [bulkValue, setBulkValue] = useState('')
+  const [bulkLoading, setBulkLoading] = useState(false)
+
+  const checkboxRef = useRef<HTMLInputElement>(null)
+
+  // Handle indeterminate state for checkbox
+  useEffect(() => {
+    if (checkboxRef.current) {
+      checkboxRef.current.indeterminate = selectedIds.size > 0 && selectedIds.size < transactions.length
+    }
+  }, [selectedIds.size, transactions.length])
+
+  async function handleBulkApply() {
+    if (!bulkAction || !bulkValue || selectedIds.size === 0) return
+
+    setBulkLoading(true)
+    try {
+      await onApplyTag(bulkValue, Array.from(selectedIds))
+      setBulkAction('')
+      setBulkValue('')
+    } catch (error) {
+      console.error('Error applying bulk action:', error)
+    } finally {
+      setBulkLoading(false)
+    }
+  }
+
+  function handleClear() {
+    onClearSelection()
+    setBulkAction('')
+    setBulkValue('')
+  }
+
+  return (
+    <div
+      className={`rounded-lg shadow p-4 transition-all duration-200 ${
+        selectedIds.size > 0
+          ? 'bg-[var(--color-accent)]/10 border-2 border-[var(--color-accent)]/30 sticky top-0 z-10'
+          : 'card'
+      }`}
+      data-testid="bulk-actions-bar"
+    >
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <input
+            ref={checkboxRef}
+            type="checkbox"
+            checked={selectedIds.size === transactions.length && transactions.length > 0}
+            onChange={onToggleAll}
+            className="w-4 h-4 rounded"
+            data-testid="select-all-checkbox"
+          />
+          <span className={`text-sm font-medium ${selectedIds.size > 0 ? 'text-[var(--color-accent)]' : 'text-theme-muted'}`}>
+            {selectedIds.size > 0
+              ? `${selectedIds.size} of ${totalCount.toLocaleString()} selected`
+              : `Select all (${transactions.length} loaded)`}
+          </span>
+        </div>
+
+        {selectedIds.size > 0 && (
+          <>
+            <div className="h-6 w-px bg-[var(--color-accent)]/30" />
+
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-[var(--color-accent)]">Assign:</span>
+              <select
+                value={bulkAction}
+                onChange={(e) => {
+                  setBulkAction(e.target.value)
+                  setBulkValue('')
+                }}
+                className="px-3 py-1.5 border border-[var(--color-accent)]/30 rounded-md text-sm bg-theme-elevated focus:ring-2 focus:ring-[var(--color-accent)]"
+                data-testid="bulk-action-type"
+              >
+                <option value="">Choose type...</option>
+                <option value="bucket">Bucket</option>
+                <option value="occasion">Occasion</option>
+                <option value="account">Account</option>
+              </select>
+
+              {bulkAction === 'bucket' && (
+                <select
+                  value={bulkValue}
+                  onChange={(e) => setBulkValue(e.target.value)}
+                  className="px-3 py-1.5 border border-[var(--color-accent)]/30 rounded-md text-sm bg-theme-elevated focus:ring-2 focus:ring-[var(--color-accent)]"
+                  data-testid="bulk-bucket-select"
+                >
+                  <option value="">Select bucket...</option>
+                  {bucketTags.map((tag) => (
+                    <option key={tag.id} value={`bucket:${tag.value}`}>
+                      {tag.value.charAt(0).toUpperCase() + tag.value.slice(1)}
+                    </option>
+                  ))}
+                </select>
+              )}
+
+              {bulkAction === 'occasion' && (
+                <select
+                  value={bulkValue}
+                  onChange={(e) => setBulkValue(e.target.value)}
+                  className="px-3 py-1.5 border border-[var(--color-accent)]/30 rounded-md text-sm bg-theme-elevated focus:ring-2 focus:ring-[var(--color-accent)]"
+                  data-testid="bulk-occasion-select"
+                >
+                  <option value="">Select occasion...</option>
+                  {occasionTags.map((tag) => (
+                    <option key={tag.id} value={`occasion:${tag.value}`}>
+                      {tag.value.charAt(0).toUpperCase() + tag.value.slice(1).replace(/-/g, ' ')}
+                    </option>
+                  ))}
+                </select>
+              )}
+
+              {bulkAction === 'account' && (
+                <select
+                  value={bulkValue}
+                  onChange={(e) => setBulkValue(e.target.value)}
+                  className="px-3 py-1.5 border border-[var(--color-accent)]/30 rounded-md text-sm bg-theme-elevated focus:ring-2 focus:ring-[var(--color-accent)]"
+                  data-testid="bulk-account-select"
+                >
+                  <option value="">Select account...</option>
+                  {accountTags.map((tag) => (
+                    <option key={tag.id} value={`account:${tag.value}`}>
+                      {tag.description || tag.value}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+
+            {bulkValue && (
+              <button
+                onClick={handleBulkApply}
+                disabled={bulkLoading}
+                className="btn-primary text-sm disabled:opacity-50"
+                data-testid="bulk-apply-btn"
+              >
+                {bulkLoading ? (
+                  <span className="flex items-center gap-2">
+                    <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                    </svg>
+                    Applying...
+                  </span>
+                ) : (
+                  `Apply to ${selectedIds.size}`
+                )}
+              </button>
+            )}
+
+            <button
+              onClick={handleClear}
+              className="ml-auto text-sm text-[var(--color-accent)] hover:opacity-80 font-medium"
+              data-testid="clear-selection-btn"
+            >
+              Clear selection
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/transactions/TransactionFilters.test.tsx
+++ b/frontend/src/components/transactions/TransactionFilters.test.tsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TransactionFiltersComponent from './TransactionFilters'
+import { Tag, INITIAL_FILTERS, TransactionFilters } from '@/types/transactions'
+
+const mockBucketTags: Tag[] = [
+  { id: 1, namespace: 'bucket', value: 'groceries' },
+  { id: 2, namespace: 'bucket', value: 'dining' },
+]
+
+const mockOccasionTags: Tag[] = [
+  { id: 3, namespace: 'occasion', value: 'vacation-2024' },
+]
+
+const mockAccountTags: Tag[] = [
+  { id: 4, namespace: 'account', value: 'checking', description: 'Main Checking' },
+  { id: 5, namespace: 'account', value: 'savings', description: 'Savings' },
+]
+
+describe('TransactionFilters', () => {
+  const defaultProps = {
+    filters: INITIAL_FILTERS,
+    searchInput: '',
+    bucketTags: mockBucketTags,
+    occasionTags: mockOccasionTags,
+    accountTags: mockAccountTags,
+    largeThreshold: 100,
+    onFiltersChange: vi.fn(),
+    onSearchInputChange: vi.fn(),
+    onSearch: vi.fn(),
+  }
+
+  it('renders quick filters', () => {
+    render(<TransactionFiltersComponent {...defaultProps} />)
+    expect(screen.getByTestId('quick-filters')).toBeInTheDocument()
+  })
+
+  it('renders main filters', () => {
+    render(<TransactionFiltersComponent {...defaultProps} />)
+    expect(screen.getByTestId('main-filters')).toBeInTheDocument()
+  })
+
+  it('renders search input', () => {
+    render(<TransactionFiltersComponent {...defaultProps} />)
+    expect(screen.getByTestId('filter-search')).toBeInTheDocument()
+  })
+
+  it('renders bucket dropdown', () => {
+    render(<TransactionFiltersComponent {...defaultProps} />)
+    expect(screen.getByTestId('filter-bucket')).toBeInTheDocument()
+  })
+
+  it('renders occasion dropdown', () => {
+    render(<TransactionFiltersComponent {...defaultProps} />)
+    expect(screen.getByTestId('filter-occasion')).toBeInTheDocument()
+  })
+
+  it('calls onSearchInputChange when search input changed', async () => {
+    const user = userEvent.setup()
+    const onSearchInputChange = vi.fn()
+    render(<TransactionFiltersComponent {...defaultProps} onSearchInputChange={onSearchInputChange} />)
+
+    await user.type(screen.getByTestId('filter-search'), 'test')
+    expect(onSearchInputChange).toHaveBeenCalled()
+  })
+
+  it('calls onSearch when Enter pressed in search', async () => {
+    const user = userEvent.setup()
+    const onSearch = vi.fn()
+    render(<TransactionFiltersComponent {...defaultProps} onSearch={onSearch} />)
+
+    const searchInput = screen.getByTestId('filter-search')
+    await user.type(searchInput, '{Enter}')
+    expect(onSearch).toHaveBeenCalled()
+  })
+
+  it('calls onSearch when search button clicked', async () => {
+    const user = userEvent.setup()
+    const onSearch = vi.fn()
+    render(<TransactionFiltersComponent {...defaultProps} onSearch={onSearch} />)
+
+    await user.click(screen.getByTestId('search-btn'))
+    expect(onSearch).toHaveBeenCalled()
+  })
+
+  it('calls onFiltersChange when bucket changed', async () => {
+    const user = userEvent.setup()
+    const onFiltersChange = vi.fn()
+    render(<TransactionFiltersComponent {...defaultProps} onFiltersChange={onFiltersChange} />)
+
+    await user.selectOptions(screen.getByTestId('filter-bucket'), 'groceries')
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ bucket: 'groceries' }))
+  })
+
+  it('calls onFiltersChange when occasion changed', async () => {
+    const user = userEvent.setup()
+    const onFiltersChange = vi.fn()
+    render(<TransactionFiltersComponent {...defaultProps} onFiltersChange={onFiltersChange} />)
+
+    await user.selectOptions(screen.getByTestId('filter-occasion'), 'vacation-2024')
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ occasion: 'vacation-2024' }))
+  })
+
+  it('shows advanced filters toggle button', () => {
+    render(<TransactionFiltersComponent {...defaultProps} />)
+    expect(screen.getByTestId('toggle-advanced-btn')).toBeInTheDocument()
+  })
+
+  it('shows advanced filters when toggle clicked', async () => {
+    const user = userEvent.setup()
+    render(<TransactionFiltersComponent {...defaultProps} />)
+
+    await user.click(screen.getByTestId('toggle-advanced-btn'))
+    expect(screen.getByTestId('advanced-filters')).toBeInTheDocument()
+  })
+
+  it('shows advanced filters when has active advanced filter', () => {
+    const filters: TransactionFilters = { ...INITIAL_FILTERS, status: 'unreconciled' }
+    render(<TransactionFiltersComponent {...defaultProps} filters={filters} />)
+    expect(screen.getByTestId('advanced-filters')).toBeInTheDocument()
+  })
+
+  it('shows status filter in advanced section', async () => {
+    const user = userEvent.setup()
+    render(<TransactionFiltersComponent {...defaultProps} />)
+
+    await user.click(screen.getByTestId('toggle-advanced-btn'))
+    expect(screen.getByTestId('filter-status')).toBeInTheDocument()
+  })
+
+  it('shows transfers filter in advanced section', async () => {
+    const user = userEvent.setup()
+    render(<TransactionFiltersComponent {...defaultProps} />)
+
+    await user.click(screen.getByTestId('toggle-advanced-btn'))
+    expect(screen.getByTestId('filter-transfers')).toBeInTheDocument()
+  })
+
+  it('shows date inputs in advanced section', async () => {
+    const user = userEvent.setup()
+    render(<TransactionFiltersComponent {...defaultProps} />)
+
+    await user.click(screen.getByTestId('toggle-advanced-btn'))
+    expect(screen.getByTestId('filter-start-date')).toBeInTheDocument()
+    expect(screen.getByTestId('filter-end-date')).toBeInTheDocument()
+  })
+
+  it('shows amount inputs in advanced section', async () => {
+    const user = userEvent.setup()
+    render(<TransactionFiltersComponent {...defaultProps} />)
+
+    await user.click(screen.getByTestId('toggle-advanced-btn'))
+    expect(screen.getByTestId('filter-amount-min')).toBeInTheDocument()
+    expect(screen.getByTestId('filter-amount-max')).toBeInTheDocument()
+  })
+
+  it('shows clear all button in advanced section', async () => {
+    const user = userEvent.setup()
+    render(<TransactionFiltersComponent {...defaultProps} />)
+
+    await user.click(screen.getByTestId('toggle-advanced-btn'))
+    expect(screen.getByTestId('clear-all-btn')).toBeInTheDocument()
+  })
+
+  it('clears filters when clear all clicked', async () => {
+    const user = userEvent.setup()
+    const onFiltersChange = vi.fn()
+    const onSearchInputChange = vi.fn()
+    const filters: TransactionFilters = { ...INITIAL_FILTERS, bucket: 'groceries' }
+    render(<TransactionFiltersComponent {...defaultProps} filters={filters} onFiltersChange={onFiltersChange} onSearchInputChange={onSearchInputChange} />)
+
+    await user.click(screen.getByTestId('toggle-advanced-btn'))
+    await user.click(screen.getByTestId('clear-all-btn'))
+    expect(onFiltersChange).toHaveBeenCalledWith(INITIAL_FILTERS)
+    expect(onSearchInputChange).toHaveBeenCalledWith('')
+  })
+
+  it('shows active filter pills when filters applied', () => {
+    const filters: TransactionFilters = { ...INITIAL_FILTERS, bucket: 'groceries' }
+    render(<TransactionFiltersComponent {...defaultProps} filters={filters} />)
+    expect(screen.getByTestId('active-filters')).toBeInTheDocument()
+    expect(screen.getByText(/Bucket: groceries/)).toBeInTheDocument()
+  })
+
+  it('shows quick filter buttons', () => {
+    render(<TransactionFiltersComponent {...defaultProps} />)
+    expect(screen.getByTestId('quick-filter-this-month')).toBeInTheDocument()
+    expect(screen.getByTestId('quick-filter-last-month')).toBeInTheDocument()
+    expect(screen.getByTestId('quick-filter-this-year')).toBeInTheDocument()
+    expect(screen.getByTestId('quick-filter-ytd')).toBeInTheDocument()
+  })
+
+  it('applies this month filter when clicked', async () => {
+    const user = userEvent.setup()
+    const onFiltersChange = vi.fn()
+    render(<TransactionFiltersComponent {...defaultProps} onFiltersChange={onFiltersChange} />)
+
+    await user.click(screen.getByTestId('quick-filter-this-month'))
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({
+      startDate: expect.any(String),
+      endDate: expect.any(String)
+    }))
+  })
+
+  it('shows account filter dropdown', () => {
+    render(<TransactionFiltersComponent {...defaultProps} />)
+    expect(screen.getByTestId('filter-accounts-btn')).toBeInTheDocument()
+  })
+
+  it('shows account options when dropdown clicked', async () => {
+    const user = userEvent.setup()
+    render(<TransactionFiltersComponent {...defaultProps} />)
+
+    await user.click(screen.getByTestId('filter-accounts-btn'))
+    expect(screen.getByTestId('accounts-dropdown')).toBeInTheDocument()
+    expect(screen.getByTestId('account-option-checking')).toBeInTheDocument()
+  })
+
+  it('displays large threshold in quick filter button', () => {
+    render(<TransactionFiltersComponent {...defaultProps} largeThreshold={200} />)
+    expect(screen.getByText(/Large.*\$200\+/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/transactions/TransactionFilters.tsx
+++ b/frontend/src/components/transactions/TransactionFilters.tsx
@@ -1,0 +1,481 @@
+'use client'
+
+import { useState } from 'react'
+import { Tag, TransactionFilters as FilterState, INITIAL_FILTERS } from '@/types/transactions'
+
+interface TransactionFiltersProps {
+  filters: FilterState
+  searchInput: string
+  bucketTags: Tag[]
+  occasionTags: Tag[]
+  accountTags: Tag[]
+  largeThreshold: number | null
+  onFiltersChange: (filters: FilterState) => void
+  onSearchInputChange: (value: string) => void
+  onSearch: () => void
+}
+
+export default function TransactionFiltersComponent({
+  filters,
+  searchInput,
+  bucketTags,
+  occasionTags,
+  accountTags,
+  largeThreshold,
+  onFiltersChange,
+  onSearchInputChange,
+  onSearch,
+}: TransactionFiltersProps) {
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [showAccountDropdown, setShowAccountDropdown] = useState(false)
+
+  // Check if we have any advanced filters active
+  const hasAdvancedFilters = filters.status ||
+    filters.amountMin ||
+    filters.amountMax ||
+    filters.startDate ||
+    filters.endDate ||
+    filters.accountsExclude.length > 0 ||
+    filters.transfers !== 'hide'
+
+  function handleQuickDate(startDate: string, endDate: string) {
+    onFiltersChange({ ...filters, startDate, endDate })
+    setShowAdvanced(true)
+  }
+
+  function clearAllFilters() {
+    onSearchInputChange('')
+    onFiltersChange(INITIAL_FILTERS)
+    setShowAccountDropdown(false)
+  }
+
+  return (
+    <>
+      {/* Quick Filters */}
+      <div className="card p-4" data-testid="quick-filters">
+        <div className="flex flex-wrap gap-4">
+          {/* Date Range Quick Filters */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-theme-muted font-medium uppercase tracking-wide">Date:</span>
+            <button
+              onClick={() => {
+                const now = new Date()
+                const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
+                const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+                handleQuickDate(firstDay.toISOString().split('T')[0], lastDay.toISOString().split('T')[0])
+              }}
+              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
+              data-testid="quick-filter-this-month"
+            >
+              This Month
+            </button>
+            <button
+              onClick={() => {
+                const now = new Date()
+                const firstDay = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+                const lastDay = new Date(now.getFullYear(), now.getMonth(), 0)
+                handleQuickDate(firstDay.toISOString().split('T')[0], lastDay.toISOString().split('T')[0])
+              }}
+              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
+              title={`${new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}`}
+              data-testid="quick-filter-last-month"
+            >
+              Last Month
+            </button>
+            <button
+              onClick={() => {
+                const now = new Date()
+                const firstDay = new Date(now.getFullYear(), 0, 1)
+                const lastDay = new Date(now.getFullYear(), 11, 31)
+                handleQuickDate(firstDay.toISOString().split('T')[0], lastDay.toISOString().split('T')[0])
+              }}
+              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
+              data-testid="quick-filter-this-year"
+            >
+              This Year
+            </button>
+            <button
+              onClick={() => {
+                const now = new Date()
+                const firstDay = new Date(now.getFullYear(), 0, 1)
+                handleQuickDate(firstDay.toISOString().split('T')[0], now.toISOString().split('T')[0])
+              }}
+              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
+              data-testid="quick-filter-ytd"
+            >
+              YTD
+            </button>
+            <button
+              onClick={() => {
+                const now = new Date()
+                const past = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000)
+                handleQuickDate(past.toISOString().split('T')[0], now.toISOString().split('T')[0])
+              }}
+              className="px-3 py-1.5 text-xs rounded-full border border-theme hover:bg-[var(--color-bg-hover)] transition-colors"
+              data-testid="quick-filter-90-days"
+            >
+              Last 90 Days
+            </button>
+          </div>
+
+          <div className="h-6 w-px bg-theme hidden sm:block" />
+
+          {/* Insight Quick Filters */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-theme-muted font-medium uppercase tracking-wide">Quick:</span>
+            <button
+              onClick={() => {
+                const now = new Date()
+                const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
+                const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+                const threshold = largeThreshold || 100
+                onFiltersChange({
+                  ...filters,
+                  startDate: firstDay.toISOString().split('T')[0],
+                  endDate: lastDay.toISOString().split('T')[0],
+                  amountMin: '',
+                  amountMax: `-${threshold}`
+                })
+                setShowAdvanced(true)
+              }}
+              className="px-3 py-1.5 text-xs rounded-full border border-orange-300 text-orange-700 bg-orange-50 hover:bg-orange-100 transition-colors dark:border-orange-700 dark:text-orange-300 dark:bg-orange-900/30 dark:hover:bg-orange-900/50"
+              title={largeThreshold ? `Large transactions this month (over $${largeThreshold} - 2σ above your average)` : 'Large transactions this month'}
+              data-testid="quick-filter-large"
+            >
+              ⚠️ Large{largeThreshold ? ` ($${largeThreshold}+)` : ''}
+            </button>
+            <button
+              onClick={() => {
+                const now = new Date()
+                const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
+                const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+                onFiltersChange({
+                  ...filters,
+                  startDate: firstDay.toISOString().split('T')[0],
+                  endDate: lastDay.toISOString().split('T')[0],
+                  amountMin: '',
+                  amountMax: '-50'
+                })
+                setShowAdvanced(true)
+              }}
+              className="px-3 py-1.5 text-xs rounded-full border border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors dark:border-blue-700 dark:text-blue-300 dark:bg-blue-900/30 dark:hover:bg-blue-900/50"
+              title="Top spending this month (over $50)"
+              data-testid="quick-filter-top-spending"
+            >
+              🏪 Top Spending
+            </button>
+            <button
+              onClick={() => {
+                onFiltersChange({
+                  ...filters,
+                  amountMin: '',
+                  amountMax: '-100'
+                })
+                setShowAdvanced(true)
+              }}
+              className="px-3 py-1.5 text-xs rounded-full border border-red-300 text-red-700 bg-red-50 hover:bg-red-100 transition-colors dark:border-red-700 dark:text-red-300 dark:bg-red-900/30 dark:hover:bg-red-900/50"
+              title="Transactions over $100"
+              data-testid="quick-filter-100"
+            >
+              💰 Large ($100+)
+            </button>
+            <button
+              onClick={() => {
+                onFiltersChange({ ...filters, status: 'unreconciled' })
+                setShowAdvanced(true)
+              }}
+              className="px-3 py-1.5 text-xs rounded-full border border-yellow-300 text-yellow-700 bg-yellow-50 hover:bg-yellow-100 transition-colors dark:border-yellow-700 dark:text-yellow-300 dark:bg-yellow-900/30 dark:hover:bg-yellow-900/50"
+              title="Transactions needing review"
+              data-testid="quick-filter-unreconciled"
+            >
+              📋 Unreconciled
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="card p-4 space-y-4" data-testid="main-filters">
+        {/* Primary filters row */}
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
+          <input
+            type="text"
+            placeholder="Search merchant or description..."
+            className="input"
+            value={searchInput}
+            onChange={(e) => onSearchInputChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') onSearch()
+            }}
+            data-testid="filter-search"
+          />
+          <select
+            className="input"
+            value={filters.bucket}
+            onChange={(e) => onFiltersChange({ ...filters, bucket: e.target.value })}
+            data-testid="filter-bucket"
+          >
+            <option value="">All Buckets</option>
+            {bucketTags.map((tag) => (
+              <option key={tag.id} value={tag.value}>
+                {tag.value.charAt(0).toUpperCase() + tag.value.slice(1)}
+              </option>
+            ))}
+          </select>
+          <select
+            className="input"
+            value={filters.occasion}
+            onChange={(e) => onFiltersChange({ ...filters, occasion: e.target.value })}
+            data-testid="filter-occasion"
+          >
+            <option value="">All Occasions</option>
+            {occasionTags.map((tag) => (
+              <option key={tag.id} value={tag.value}>
+                {tag.value.charAt(0).toUpperCase() + tag.value.slice(1).replace(/-/g, ' ')}
+              </option>
+            ))}
+          </select>
+
+          {/* Account dropdown */}
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setShowAccountDropdown(!showAccountDropdown)}
+              className="w-full px-4 py-2 border border-theme rounded-md text-left flex justify-between items-center bg-theme-elevated"
+              data-testid="filter-accounts-btn"
+            >
+              <span className={filters.accounts.length > 0 || filters.accountsExclude.length > 0 ? 'text-theme' : 'text-theme-muted'}>
+                {filters.accounts.length > 0
+                  ? `${filters.accounts.length} selected`
+                  : filters.accountsExclude.length > 0
+                    ? `Excluding ${filters.accountsExclude.length}`
+                    : 'All Accounts'}
+              </span>
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            {showAccountDropdown && (
+              <div className="absolute z-20 mt-1 w-72 bg-theme-elevated border border-theme rounded-md shadow-lg max-h-64 overflow-y-auto" data-testid="accounts-dropdown">
+                <div className="p-2 border-b border-theme text-xs text-theme-muted">
+                  Click to include, Shift+Click to exclude
+                </div>
+                {accountTags.map((tag) => {
+                  const isIncluded = filters.accounts.includes(tag.value)
+                  const isExcluded = filters.accountsExclude.includes(tag.value)
+                  return (
+                    <div
+                      key={tag.id}
+                      onClick={(e) => {
+                        if (e.shiftKey) {
+                          if (isExcluded) {
+                            onFiltersChange({
+                              ...filters,
+                              accountsExclude: filters.accountsExclude.filter(a => a !== tag.value)
+                            })
+                          } else {
+                            onFiltersChange({
+                              ...filters,
+                              accounts: filters.accounts.filter(a => a !== tag.value),
+                              accountsExclude: [...filters.accountsExclude, tag.value]
+                            })
+                          }
+                        } else {
+                          if (isIncluded) {
+                            onFiltersChange({
+                              ...filters,
+                              accounts: filters.accounts.filter(a => a !== tag.value)
+                            })
+                          } else {
+                            onFiltersChange({
+                              ...filters,
+                              accounts: [...filters.accounts, tag.value],
+                              accountsExclude: filters.accountsExclude.filter(a => a !== tag.value)
+                            })
+                          }
+                        }
+                      }}
+                      className={`px-3 py-2 cursor-pointer flex items-center gap-2 text-sm ${
+                        isIncluded ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]' :
+                        isExcluded ? 'bg-negative text-negative' :
+                        'hover:bg-[var(--color-bg-hover)]'
+                      }`}
+                      data-testid={`account-option-${tag.value}`}
+                    >
+                      <span className={`w-4 h-4 border rounded flex items-center justify-center text-xs ${
+                        isIncluded ? 'bg-[var(--color-accent)] border-[var(--color-accent)] text-white' :
+                        isExcluded ? 'bg-[var(--color-negative)] border-[var(--color-negative)] text-white' :
+                        'border-theme'
+                      }`}>
+                        {isIncluded && '✓'}
+                        {isExcluded && '−'}
+                      </span>
+                      <span>{tag.description || tag.value}</span>
+                    </div>
+                  )
+                })}
+                {(filters.accounts.length > 0 || filters.accountsExclude.length > 0) && (
+                  <div className="p-2 border-t border-theme">
+                    <button
+                      onClick={() => onFiltersChange({ ...filters, accounts: [], accountsExclude: [] })}
+                      className="text-xs text-theme-muted hover:text-theme"
+                    >
+                      Clear selection
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              onClick={onSearch}
+              className="flex-1 btn-primary"
+              data-testid="search-btn"
+            >
+              Search
+            </button>
+            <button
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              className={`px-3 py-2 border border-theme rounded-md ${showAdvanced ? 'bg-[var(--color-bg-hover)]' : ''}`}
+              title="Advanced filters"
+              data-testid="toggle-advanced-btn"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Advanced filters (collapsible) */}
+        {(showAdvanced || hasAdvancedFilters) && (
+          <div className="pt-4 border-t border-theme" data-testid="advanced-filters">
+            <div className="grid grid-cols-1 md:grid-cols-6 gap-4">
+              <select
+                className="input"
+                value={filters.status}
+                onChange={(e) => onFiltersChange({ ...filters, status: e.target.value })}
+                data-testid="filter-status"
+              >
+                <option value="">All Status</option>
+                <option value="unreconciled">Unreconciled</option>
+                <option value="matched">Matched</option>
+                <option value="manually_entered">Manually Entered</option>
+                <option value="ignored">Ignored</option>
+              </select>
+              <select
+                className="input"
+                value={filters.transfers}
+                onChange={(e) => onFiltersChange({ ...filters, transfers: e.target.value as 'all' | 'hide' | 'only' })}
+                title="Filter internal transfers (CC payments, bank transfers)"
+                data-testid="filter-transfers"
+              >
+                <option value="hide">Hide Transfers</option>
+                <option value="all">All Transactions</option>
+                <option value="only">Transfers Only</option>
+              </select>
+              <div className="flex gap-2 items-center">
+                <input
+                  type="number"
+                  placeholder="Min $"
+                  className="input w-full"
+                  value={filters.amountMin}
+                  onChange={(e) => onFiltersChange({ ...filters, amountMin: e.target.value })}
+                  data-testid="filter-amount-min"
+                />
+                <span className="text-theme-muted">–</span>
+                <input
+                  type="number"
+                  placeholder="Max $"
+                  className="input w-full"
+                  value={filters.amountMax}
+                  onChange={(e) => onFiltersChange({ ...filters, amountMax: e.target.value })}
+                  data-testid="filter-amount-max"
+                />
+              </div>
+              <input
+                type="date"
+                className="input"
+                value={filters.startDate}
+                onChange={(e) => onFiltersChange({ ...filters, startDate: e.target.value })}
+                title="Start date"
+                data-testid="filter-start-date"
+              />
+              <input
+                type="date"
+                className="input"
+                value={filters.endDate}
+                onChange={(e) => onFiltersChange({ ...filters, endDate: e.target.value })}
+                title="End date"
+                data-testid="filter-end-date"
+              />
+              <button
+                onClick={clearAllFilters}
+                className="px-4 py-2 text-theme-muted border border-theme rounded-md hover:bg-[var(--color-bg-hover)]"
+                data-testid="clear-all-btn"
+              >
+                Clear All
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Active filters pills */}
+        {(filters.bucket || filters.occasion || filters.accounts.length > 0 || filters.accountsExclude.length > 0 || filters.status || filters.amountMin || filters.amountMax || filters.startDate || filters.endDate || filters.transfers !== 'hide') && (
+          <div className="flex flex-wrap gap-2 pt-2" data-testid="active-filters">
+            {filters.bucket && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-800 rounded-full text-xs dark:bg-green-900/30 dark:text-green-300">
+                Bucket: {filters.bucket}
+                <button onClick={() => onFiltersChange({ ...filters, bucket: '' })} className="hover:text-green-900">×</button>
+              </span>
+            )}
+            {filters.occasion && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-purple-100 text-purple-800 rounded-full text-xs dark:bg-purple-900/30 dark:text-purple-300">
+                Occasion: {filters.occasion.replace(/-/g, ' ')}
+                <button onClick={() => onFiltersChange({ ...filters, occasion: '' })} className="hover:text-purple-900">×</button>
+              </span>
+            )}
+            {filters.accounts.map(acc => (
+              <span key={`inc-${acc}`} className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs dark:bg-blue-900/30 dark:text-blue-300">
+                Account: {accountTags.find(t => t.value === acc)?.description || acc}
+                <button onClick={() => onFiltersChange({ ...filters, accounts: filters.accounts.filter(a => a !== acc) })} className="hover:text-blue-900">×</button>
+              </span>
+            ))}
+            {filters.accountsExclude.map(acc => (
+              <span key={`exc-${acc}`} className="inline-flex items-center gap-1 px-2 py-1 bg-red-100 text-red-800 rounded-full text-xs dark:bg-red-900/30 dark:text-red-300">
+                NOT: {accountTags.find(t => t.value === acc)?.description || acc}
+                <button onClick={() => onFiltersChange({ ...filters, accountsExclude: filters.accountsExclude.filter(a => a !== acc) })} className="hover:text-red-900">×</button>
+              </span>
+            ))}
+            {filters.status && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-yellow-100 text-yellow-800 rounded-full text-xs dark:bg-yellow-900/30 dark:text-yellow-300">
+                Status: {filters.status}
+                <button onClick={() => onFiltersChange({ ...filters, status: '' })} className="hover:text-yellow-900">×</button>
+              </span>
+            )}
+            {(filters.amountMin || filters.amountMax) && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-orange-100 text-orange-800 rounded-full text-xs dark:bg-orange-900/30 dark:text-orange-300">
+                Amount: {filters.amountMin || '∞'} – {filters.amountMax || '∞'}
+                <button onClick={() => onFiltersChange({ ...filters, amountMin: '', amountMax: '' })} className="hover:text-orange-900">×</button>
+              </span>
+            )}
+            {(filters.startDate || filters.endDate) && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 text-gray-800 rounded-full text-xs dark:bg-gray-700 dark:text-gray-300">
+                Date: {filters.startDate || '...'} – {filters.endDate || '...'}
+                <button onClick={() => onFiltersChange({ ...filters, startDate: '', endDate: '' })} className="hover:text-gray-900">×</button>
+              </span>
+            )}
+            {filters.transfers !== 'hide' && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs dark:bg-blue-900/30 dark:text-blue-300">
+                {filters.transfers === 'all' ? 'Including Transfers' : 'Transfers Only'}
+                <button onClick={() => onFiltersChange({ ...filters, transfers: 'hide' })} className="hover:text-blue-900">×</button>
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/transactions/TransactionRow.test.tsx
+++ b/frontend/src/components/transactions/TransactionRow.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TransactionRow from './TransactionRow'
+import { Transaction, Tag, TransactionTag } from '@/types/transactions'
+
+const mockBucketTags: Tag[] = [
+  { id: 1, namespace: 'bucket', value: 'groceries' },
+  { id: 2, namespace: 'bucket', value: 'dining' },
+]
+
+const mockAccountTags: Tag[] = [
+  { id: 3, namespace: 'account', value: 'checking', description: 'Main Checking' },
+]
+
+const mockAllTags: Tag[] = [
+  ...mockBucketTags,
+  ...mockAccountTags,
+  { id: 4, namespace: 'occasion', value: 'vacation-2024', description: 'Summer Vacation' },
+]
+
+const mockTransaction: Transaction = {
+  id: 1,
+  date: '2024-12-01',
+  amount: -50.25,
+  description: 'GROCERY STORE #1234',
+  merchant: 'Grocery Store',
+  account_source: 'checking',
+  account_tag_id: 3,
+  category: null,
+  reconciliation_status: 'unreconciled',
+  tags: [{ namespace: 'bucket', value: 'groceries', full: 'bucket:groceries' }],
+  bucket: 'groceries',
+  account: 'checking',
+}
+
+describe('TransactionRow', () => {
+  const defaultProps = {
+    transaction: mockTransaction,
+    isSelected: false,
+    isExpanded: false,
+    bucketTags: mockBucketTags,
+    accountTags: mockAccountTags,
+    allTags: mockAllTags,
+    onToggleSelect: vi.fn(),
+    onToggleExpand: vi.fn(),
+    onBucketChange: vi.fn(),
+    onAccountChange: vi.fn(),
+    onRemoveTag: vi.fn(),
+    onAddTag: vi.fn(),
+    onToggleTransfer: vi.fn(),
+    onUnlinkTransfer: vi.fn(),
+    onSaveNote: vi.fn(),
+    onTransactionsChanged: vi.fn(),
+  }
+
+  it('renders transaction row', () => {
+    render(<TransactionRow {...defaultProps} />)
+    expect(screen.getByTestId('transaction-row-1')).toBeInTheDocument()
+  })
+
+  it('displays merchant name', () => {
+    render(<TransactionRow {...defaultProps} />)
+    expect(screen.getByText('Grocery Store')).toBeInTheDocument()
+  })
+
+  it('displays formatted amount', () => {
+    render(<TransactionRow {...defaultProps} />)
+    expect(screen.getByText('-$50.25')).toBeInTheDocument()
+  })
+
+  it('displays formatted date', () => {
+    render(<TransactionRow {...defaultProps} />)
+    expect(screen.getByText('12/01/2024')).toBeInTheDocument()
+  })
+
+  it('shows selected styling when selected', () => {
+    render(<TransactionRow {...defaultProps} isSelected={true} />)
+    const row = screen.getByTestId('transaction-row-1')
+    expect(row.className).toContain('bg-[var(--color-accent)]/10')
+  })
+
+  it('checkbox is checked when selected', () => {
+    render(<TransactionRow {...defaultProps} isSelected={true} />)
+    const checkbox = screen.getByTestId('txn-checkbox-1') as HTMLInputElement
+    expect(checkbox.checked).toBe(true)
+  })
+
+  it('calls onToggleSelect when checkbox clicked', async () => {
+    const user = userEvent.setup()
+    const onToggleSelect = vi.fn()
+    render(<TransactionRow {...defaultProps} onToggleSelect={onToggleSelect} />)
+
+    await user.click(screen.getByTestId('txn-checkbox-1'))
+    expect(onToggleSelect).toHaveBeenCalled()
+  })
+
+  it('calls onToggleExpand when expand button clicked', async () => {
+    const user = userEvent.setup()
+    const onToggleExpand = vi.fn()
+    render(<TransactionRow {...defaultProps} onToggleExpand={onToggleExpand} />)
+
+    await user.click(screen.getByTestId('txn-expand-1'))
+    expect(onToggleExpand).toHaveBeenCalled()
+  })
+
+  it('shows expanded section when isExpanded', () => {
+    render(<TransactionRow {...defaultProps} isExpanded={true} />)
+    expect(screen.getByTestId('txn-expanded-1')).toBeInTheDocument()
+    expect(screen.getByText('unreconciled')).toBeInTheDocument()
+  })
+
+  it('displays bucket dropdown with correct value', () => {
+    render(<TransactionRow {...defaultProps} />)
+    const select = screen.getByTestId('txn-bucket-1') as HTMLSelectElement
+    expect(select.value).toBe('groceries')
+  })
+
+  it('calls onBucketChange when bucket changed', async () => {
+    const user = userEvent.setup()
+    const onBucketChange = vi.fn()
+    render(<TransactionRow {...defaultProps} onBucketChange={onBucketChange} />)
+
+    await user.selectOptions(screen.getByTestId('txn-bucket-1'), 'dining')
+    expect(onBucketChange).toHaveBeenCalledWith(1, 'dining')
+  })
+
+  it('displays account dropdown with correct value', () => {
+    render(<TransactionRow {...defaultProps} />)
+    const select = screen.getByTestId('txn-account-1') as HTMLSelectElement
+    expect(select.value).toBe('checking')
+  })
+
+  it('calls onAccountChange when account changed', async () => {
+    const user = userEvent.setup()
+    const onAccountChange = vi.fn()
+    render(<TransactionRow {...defaultProps} onAccountChange={onAccountChange} />)
+
+    const select = screen.getByTestId('txn-account-1')
+    await user.selectOptions(select, '')
+    expect(onAccountChange).toHaveBeenCalledWith(1, '')
+  })
+
+  it('shows transfer badge when is_transfer is true', () => {
+    const transferTxn = { ...mockTransaction, is_transfer: true }
+    render(<TransactionRow {...defaultProps} transaction={transferTxn} />)
+    expect(screen.getByText('Transfer')).toBeInTheDocument()
+  })
+
+  it('shows add tag button', () => {
+    render(<TransactionRow {...defaultProps} />)
+    expect(screen.getByTestId('txn-add-tag-btn-1')).toBeInTheDocument()
+  })
+
+  it('shows tag selector when add tag clicked', async () => {
+    const user = userEvent.setup()
+    render(<TransactionRow {...defaultProps} />)
+
+    await user.click(screen.getByTestId('txn-add-tag-btn-1'))
+    expect(screen.getByTestId('txn-add-tag-select-1')).toBeInTheDocument()
+  })
+
+  it('shows expanded transfer toggle', () => {
+    render(<TransactionRow {...defaultProps} isExpanded={true} />)
+    expect(screen.getByTestId('txn-toggle-transfer-1')).toBeInTheDocument()
+  })
+
+  it('calls onToggleTransfer when transfer button clicked', async () => {
+    const user = userEvent.setup()
+    const onToggleTransfer = vi.fn()
+    render(<TransactionRow {...defaultProps} isExpanded={true} onToggleTransfer={onToggleTransfer} />)
+
+    await user.click(screen.getByTestId('txn-toggle-transfer-1'))
+    expect(onToggleTransfer).toHaveBeenCalledWith(1, false)
+  })
+
+  it('shows edit note button in expanded view', () => {
+    render(<TransactionRow {...defaultProps} isExpanded={true} />)
+    expect(screen.getByTestId('txn-edit-note-1')).toBeInTheDocument()
+  })
+
+  it('shows unlink button when linked_transaction_id present', () => {
+    const linkedTxn = { ...mockTransaction, linked_transaction_id: 2 }
+    render(<TransactionRow {...defaultProps} transaction={linkedTxn} isExpanded={true} />)
+    expect(screen.getByTestId('txn-unlink-1')).toBeInTheDocument()
+    expect(screen.getByText('#2')).toBeInTheDocument()
+  })
+
+  it('displays positive amount in green', () => {
+    const positiveTxn = { ...mockTransaction, amount: 100 }
+    render(<TransactionRow {...defaultProps} transaction={positiveTxn} />)
+    expect(screen.getByText('+$100.00')).toBeInTheDocument()
+    const amountElement = screen.getByText('+$100.00')
+    expect(amountElement.className).toContain('text-positive')
+  })
+})

--- a/frontend/src/hooks/useBulkSelection.test.ts
+++ b/frontend/src/hooks/useBulkSelection.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBulkSelection } from './useBulkSelection'
+
+interface TestItem {
+  id: number
+  name: string
+}
+
+const testItems: TestItem[] = [
+  { id: 1, name: 'Item 1' },
+  { id: 2, name: 'Item 2' },
+  { id: 3, name: 'Item 3' },
+]
+
+describe('useBulkSelection', () => {
+  it('starts with no selections', () => {
+    const { result } = renderHook(() => useBulkSelection<TestItem>())
+    expect(result.current.selectedCount).toBe(0)
+    expect(result.current.selectedIds.size).toBe(0)
+  })
+
+  it('can toggle selection on', () => {
+    const { result } = renderHook(() => useBulkSelection<TestItem>())
+
+    act(() => {
+      result.current.toggle(1)
+    })
+
+    expect(result.current.isSelected(1)).toBe(true)
+    expect(result.current.selectedCount).toBe(1)
+  })
+
+  it('can toggle selection off', () => {
+    const { result } = renderHook(() => useBulkSelection<TestItem>())
+
+    act(() => {
+      result.current.toggle(1)
+    })
+
+    act(() => {
+      result.current.toggle(1)
+    })
+
+    expect(result.current.isSelected(1)).toBe(false)
+    expect(result.current.selectedCount).toBe(0)
+  })
+
+  it('can select all items', () => {
+    const { result } = renderHook(() => useBulkSelection<TestItem>())
+
+    act(() => {
+      result.current.selectAll(testItems)
+    })
+
+    expect(result.current.selectedCount).toBe(3)
+    expect(result.current.isSelected(1)).toBe(true)
+    expect(result.current.isSelected(2)).toBe(true)
+    expect(result.current.isSelected(3)).toBe(true)
+  })
+
+  it('toggleAll selects all when none selected', () => {
+    const { result } = renderHook(() => useBulkSelection<TestItem>())
+
+    act(() => {
+      result.current.toggleAll(testItems)
+    })
+
+    expect(result.current.selectedCount).toBe(3)
+    expect(result.current.isAllSelected(testItems)).toBe(true)
+  })
+
+  it('toggleAll deselects all when all selected', () => {
+    const { result } = renderHook(() => useBulkSelection<TestItem>())
+
+    act(() => {
+      result.current.selectAll(testItems)
+    })
+
+    act(() => {
+      result.current.toggleAll(testItems)
+    })
+
+    expect(result.current.selectedCount).toBe(0)
+    expect(result.current.isAllSelected(testItems)).toBe(false)
+  })
+
+  it('can clear selection', () => {
+    const { result } = renderHook(() => useBulkSelection<TestItem>())
+
+    act(() => {
+      result.current.toggle(1)
+      result.current.toggle(2)
+    })
+
+    act(() => {
+      result.current.clearSelection()
+    })
+
+    expect(result.current.selectedCount).toBe(0)
+  })
+
+  it('isIndeterminate when some but not all selected', () => {
+    const { result } = renderHook(() => useBulkSelection<TestItem>())
+
+    act(() => {
+      result.current.toggle(1)
+    })
+
+    expect(result.current.isIndeterminate(testItems)).toBe(true)
+    expect(result.current.isAllSelected(testItems)).toBe(false)
+  })
+
+  it('isAllSelected returns false for empty items array', () => {
+    const { result } = renderHook(() => useBulkSelection<TestItem>())
+
+    expect(result.current.isAllSelected([])).toBe(false)
+  })
+})

--- a/frontend/src/hooks/useBulkSelection.ts
+++ b/frontend/src/hooks/useBulkSelection.ts
@@ -1,0 +1,71 @@
+import { useState, useCallback } from 'react'
+
+export interface UseBulkSelectionReturn<T extends { id: number }> {
+  selectedIds: Set<number>
+  isSelected: (id: number) => boolean
+  toggle: (id: number) => void
+  toggleAll: (items: T[]) => void
+  selectAll: (items: T[]) => void
+  clearSelection: () => void
+  isAllSelected: (items: T[]) => boolean
+  isIndeterminate: (items: T[]) => boolean
+  selectedCount: number
+}
+
+export function useBulkSelection<T extends { id: number }>(): UseBulkSelectionReturn<T> {
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+
+  const isSelected = useCallback((id: number) => selectedIds.has(id), [selectedIds])
+
+  const toggle = useCallback((id: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }, [])
+
+  const toggleAll = useCallback((items: T[]) => {
+    setSelectedIds(prev => {
+      if (prev.size === items.length) {
+        return new Set()
+      } else {
+        return new Set(items.map(item => item.id))
+      }
+    })
+  }, [])
+
+  const selectAll = useCallback((items: T[]) => {
+    setSelectedIds(new Set(items.map(item => item.id)))
+  }, [])
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set())
+  }, [])
+
+  const isAllSelected = useCallback(
+    (items: T[]) => items.length > 0 && selectedIds.size === items.length,
+    [selectedIds]
+  )
+
+  const isIndeterminate = useCallback(
+    (items: T[]) => selectedIds.size > 0 && selectedIds.size < items.length,
+    [selectedIds]
+  )
+
+  return {
+    selectedIds,
+    isSelected,
+    toggle,
+    toggleAll,
+    selectAll,
+    clearSelection,
+    isAllSelected,
+    isIndeterminate,
+    selectedCount: selectedIds.size,
+  }
+}

--- a/frontend/src/types/transactions.ts
+++ b/frontend/src/types/transactions.ts
@@ -1,0 +1,82 @@
+// Shared types for transactions feature
+
+export interface Tag {
+  id: number
+  namespace: string
+  value: string
+  description?: string
+}
+
+export interface TransactionTag {
+  namespace: string
+  value: string
+  full: string
+}
+
+export interface Transaction {
+  id: number
+  date: string
+  amount: number
+  description: string
+  merchant: string | null
+  account_source: string
+  account_tag_id: number | null
+  category: string | null
+  reconciliation_status: string
+  notes?: string | null
+  tags?: TransactionTag[]
+  bucket?: string
+  account?: string
+  is_transfer?: boolean
+  linked_transaction_id?: number | null
+}
+
+export interface TransactionFilters {
+  search: string
+  bucket: string
+  occasion: string
+  accounts: string[]
+  accountsExclude: string[]
+  status: string
+  amountMin: string
+  amountMax: string
+  startDate: string
+  endDate: string
+  transfers: 'all' | 'hide' | 'only'
+}
+
+export const INITIAL_FILTERS: TransactionFilters = {
+  search: '',
+  bucket: '',
+  occasion: '',
+  accounts: [],
+  accountsExclude: [],
+  status: '',
+  amountMin: '',
+  amountMax: '',
+  startDate: '',
+  endDate: '',
+  transfers: 'hide'
+}
+
+// Bucket color mapping for left border
+export const BUCKET_COLORS: Record<string, string> = {
+  'groceries': 'border-l-green-500',
+  'dining': 'border-l-orange-500',
+  'entertainment': 'border-l-purple-500',
+  'transportation': 'border-l-blue-500',
+  'utilities': 'border-l-yellow-500',
+  'housing': 'border-l-indigo-500',
+  'healthcare': 'border-l-red-500',
+  'shopping': 'border-l-pink-500',
+  'subscriptions': 'border-l-cyan-500',
+  'education': 'border-l-teal-500',
+  'income': 'border-l-emerald-500',
+  'other': 'border-l-gray-400',
+  'none': 'border-l-gray-300',
+}
+
+export function getBucketBorderColor(bucket: string | null | undefined): string {
+  if (!bucket) return 'border-l-gray-200'
+  return BUCKET_COLORS[bucket.toLowerCase()] || 'border-l-gray-400'
+}


### PR DESCRIPTION
## Summary

- Reduce transactions/page.tsx from 1639 to 487 lines (70% reduction)
- Extract 3 components: TransactionFilters, TransactionRow, BulkActionsBar
- Extract 1 reusable hook: useBulkSelection
- Create shared types module for transactions feature
- Add 70 new unit tests for extracted components

## Components Extracted

| Component | Lines | Purpose |
|-----------|-------|---------|
| TransactionFilters | ~400 | Quick filters, main filters, advanced filters |
| TransactionRow | ~400 | Desktop/mobile row with expanded metadata |
| BulkActionsBar | ~180 | Bulk selection UI with action dropdowns |
| useBulkSelection | ~60 | Generic bulk selection state hook |
| types/transactions.ts | ~70 | Shared types, filters, bucket colors |

## Test plan

- [x] All 778 tests pass (frontend + backend)
- [x] Build passes (`make build-frontend`)
- [ ] E2E tests pass in CI
- [ ] Manual smoke test of transaction filtering, selection, bulk actions