### PR TITLE
fix: update generate-pseudo-locale for v3 ESM module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci
 
       - name: Generate pseudo-locale for i18n tests
-        run: node scripts/generate-pseudo-locale.js
+        run: node scripts/generate-pseudo-locale.mjs
 
       - name: Run linter
         run: npm run lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p public
 # Generate pseudo-locale for QA testing (only if enabled)
 RUN if [ "$ENABLE_PSEUDO" = "true" ]; then \
       echo "==> ENABLE_PSEUDO=true: Generating pseudo-locale for QA testing..."; \
-      node scripts/generate-pseudo-locale.js; \
+      node scripts/generate-pseudo-locale.mjs; \
       echo "==> Pseudo-locale generated successfully"; \
     else \
       echo "==> ENABLE_PSEUDO=false: Skipping pseudo-locale (set ENABLE_PSEUDO=true in .env to enable)"; \

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,7 +39,7 @@
         "jsdom": "^27.2.0",
         "msw": "^2.12.4",
         "postcss": "^8.5.6",
-        "pseudo-localization": "^2.4.0",
+        "pseudo-localization": "^3.1.1",
         "tailwindcss": "^4.1.17",
         "typescript": "^5.9.3",
         "vitest": "^4.0.14"
@@ -6097,16 +6097,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -6281,16 +6271,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stdin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/get-stream": {
@@ -8694,33 +8674,16 @@
       "license": "MIT"
     },
     "node_modules/pseudo-localization": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/pseudo-localization/-/pseudo-localization-2.4.0.tgz",
-      "integrity": "sha512-ISYMOKY8+f+PmiXMFw2y6KLY74LBrv/8ml/VjjoVEV2k+MS+OJZz7ydciK5ntJwxPrKQPTU1+oXq9Mx2b0zEzg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pseudo-localization/-/pseudo-localization-3.1.1.tgz",
+      "integrity": "sha512-AyQ7LzuGECPyjHLcPHJDsldAQU7pEvv60kWE71AhDMVPeH5d5XLKoLchpuUoa/AlfjcDqAodh46Cyy6POCY6sw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "flat": "^5.0.2",
-        "get-stdin": "^7.0.0",
-        "typescript": "^4.7.4",
-        "yargs": "^17.2.1"
-      },
       "bin": {
-        "pseudo-localization": "bin/pseudo-localize"
-      }
-    },
-    "node_modules/pseudo-localization/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "pseudo-localization": "dist/bin/pseudo-localize.js"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": "^23"
       }
     },
     "node_modules/punycode": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "jsdom": "^27.2.0",
     "msw": "^2.12.4",
     "postcss": "^8.5.6",
-    "pseudo-localization": "^2.4.0",
+    "pseudo-localization": "^3.1.1",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3",
     "vitest": "^4.0.14"

--- a/frontend/scripts/generate-pseudo-locale.mjs
+++ b/frontend/scripts/generate-pseudo-locale.mjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable @typescript-eslint/no-require-imports */
 /**
  * Generates a pseudo-localized version of en-US.json for i18n testing.
  *
@@ -8,12 +7,16 @@
  * 2. UI can't handle longer strings (padding simulates ~30% expansion)
  * 3. Character encoding issues exist (accents test unicode)
  *
- * Usage: node scripts/generate-pseudo-locale.js
+ * Usage: node scripts/generate-pseudo-locale.mjs
  */
 
-const fs = require('fs');
-const path = require('path');
-const { localize } = require('pseudo-localization');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { pseudoLocalizeString as localize } from 'pseudo-localization';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const MESSAGES_DIR = path.join(__dirname, '../src/messages');
 const SOURCE_FILE = path.join(MESSAGES_DIR, 'en-US.json');

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -15,7 +15,7 @@ backend: ## Run backend server (runs migrations first)
 frontend: ## Run frontend development server
 	@if [ "$$ENABLE_PSEUDO" = "true" ]; then \
 		echo "$(BLUE)ENABLE_PSEUDO=true: Regenerating pseudo-locale...$(NC)"; \
-		cd $(FRONTEND_DIR) && node scripts/generate-pseudo-locale.js; \
+		cd $(FRONTEND_DIR) && node scripts/generate-pseudo-locale.mjs; \
 	fi
 	@echo "$(BLUE)Starting frontend server...$(NC)"
 	@cd $(FRONTEND_DIR) && npm run dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "maxwells-wallet",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary
- Convert script to ESM (.mjs extension) for pseudo-localization v3 compatibility
- Update import to use new export name (`pseudoLocalizeString` instead of `localize`)
- Update all Makefile/CI/Docker references

Closes #148