### PR TITLE
feat: add SWAG demo deployment with Cloudflare tunnel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ site/
 
 # Backup files
 backend/data/backups/
+deploy/swag-test/.env

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -758,7 +758,7 @@ wheels = [
 
 [[package]]
 name = "maxwells-wallet-backend"
-version = "0.10.0b1"
+version = "0.10.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/deploy/swag-test/.env.example
+++ b/deploy/swag-test/.env.example
@@ -1,0 +1,7 @@
+# SWAG Demo Deployment Configuration
+# Copy to .env and fill in your values
+
+# Cloudflare Tunnel Token (required for external access)
+# Create at: https://one.dash.cloudflare.com/ → Networks → Tunnels
+# Configure public hostname to point to: http://swag:80
+CLOUDFLARE_TUNNEL_TOKEN=

--- a/deploy/swag-test/Makefile
+++ b/deploy/swag-test/Makefile
@@ -1,0 +1,101 @@
+# =============================================================================
+# SWAG Demo Deployment
+# =============================================================================
+#
+# Runs Maxwell's Wallet behind SWAG reverse proxy in demo mode.
+# Data resets every hour. Optionally exposes via Cloudflare tunnel.
+#
+# Quick start:
+#   make up          - Start local demo at http://localhost:8888
+#   make cloudflare  - Start with Cloudflare tunnel (prompts for token)
+#   make down        - Stop everything
+#
+# Prerequisites:
+#   - Docker with Compose v2
+#   - Cloudflare account (for tunnel, optional)
+#
+# Files:
+#   docker-compose.yaml      - Main stack (SWAG + app)
+#   docker-compose.dind.yaml - Docker-in-Docker for testing
+#   swag/nginx.conf          - Reverse proxy config
+#   .env                     - Cloudflare token (create from .env.example)
+#
+# =============================================================================
+
+.DEFAULT_GOAL := help
+
+BLUE := \033[0;34m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m
+RED := \033[0;31m
+NC := \033[0m
+
+.PHONY: help up down logs cloudflare tunnel-setup clean test
+
+help: ## Show this help
+	@echo "$(BLUE)SWAG Demo Deployment$(NC)"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(YELLOW)%-15s$(NC) %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Examples:"
+	@echo "  make up              Start local demo"
+	@echo "  make cloudflare      Start with Cloudflare tunnel"
+
+up: ## Start SWAG + app in demo mode (http://localhost:8888)
+	@echo "$(BLUE)Starting SWAG demo...$(NC)"
+	docker compose up -d --build
+	@echo "$(GREEN)✓ Started$(NC)"
+	@echo ""
+	@echo "Access at: http://localhost:8888"
+	@echo "$(YELLOW)Demo mode - data resets hourly$(NC)"
+
+down: ## Stop all services
+	@echo "$(BLUE)Stopping...$(NC)"
+	docker compose --profile cloudflare down
+	@echo "$(GREEN)✓ Stopped$(NC)"
+
+logs: ## View container logs
+	docker compose logs -f
+
+cloudflare: tunnel-setup ## Start with Cloudflare tunnel (prompts for token if needed)
+	@echo "$(BLUE)Starting with Cloudflare tunnel...$(NC)"
+	docker compose --profile cloudflare up -d --build
+	@echo "$(GREEN)✓ Started with Cloudflare tunnel$(NC)"
+	@echo ""
+	@echo "Local: http://localhost:8888"
+	@echo "External: Via your Cloudflare tunnel hostname"
+
+tunnel-setup: ## Configure Cloudflare tunnel token interactively
+	@if [ -f ".env" ] && grep -q "CLOUDFLARE_TUNNEL_TOKEN=." ".env"; then \
+		echo "$(GREEN)✓ Tunnel token already configured$(NC)"; \
+		read -p "Reconfigure? [y/N] " confirm; \
+		if [ "$$confirm" != "y" ] && [ "$$confirm" != "Y" ]; then \
+			exit 0; \
+		fi; \
+	fi; \
+	echo ""; \
+	echo "$(BLUE)Cloudflare Tunnel Setup$(NC)"; \
+	echo ""; \
+	echo "1. Go to: https://one.dash.cloudflare.com/"; \
+	echo "2. Navigate to: Networks → Tunnels → Create"; \
+	echo "3. Configure public hostname to point to: http://swag:80"; \
+	echo "4. Copy the tunnel token"; \
+	echo ""; \
+	read -p "Paste your Cloudflare Tunnel Token: " token; \
+	if [ -z "$$token" ]; then \
+		echo "$(RED)✗ No token provided$(NC)"; \
+		exit 1; \
+	fi; \
+	echo "CLOUDFLARE_TUNNEL_TOKEN=$$token" > .env; \
+	echo "$(GREEN)✓ Token saved to .env$(NC)"
+
+clean: ## Remove containers, volumes, and .env
+	@echo "$(RED)Removing containers and volumes...$(NC)"
+	docker compose --profile cloudflare down -v
+	rm -f .env
+	@echo "$(GREEN)✓ Cleaned$(NC)"
+
+test: ## Run configuration tests
+	@echo "$(BLUE)Running tests...$(NC)"
+	cd ../.. && cd backend && uv run python -m pytest ../deploy/swag-test/test_config.py -v
+	@echo "$(GREEN)✓ Tests passed$(NC)"

--- a/deploy/swag-test/README.md
+++ b/deploy/swag-test/README.md
@@ -1,0 +1,119 @@
+# SWAG Demo Deployment
+
+Maxwell's Wallet behind [SWAG](https://docs.linuxserver.io/general/swag/) reverse proxy in **demo mode**, targeting single-LXC homelab deployment.
+
+**Demo Mode Features:**
+- Pre-seeded with sample transactions and budgets
+- Resets to clean demo data every hour
+- Destructive operations blocked (purge, bulk delete)
+- "Demo Mode" banner in UI
+
+## Local Testing
+
+```bash
+cd deploy/swag-test
+
+make up          # Start local demo (http://localhost:8888)
+make cloudflare  # Start with Cloudflare tunnel (prompts for token)
+make logs        # View logs
+make down        # Stop everything
+make help        # Show all commands
+```
+
+### Docker-in-Docker (simulates LXC)
+
+Full isolation - simulates Docker running inside an LXC:
+
+```bash
+cd deploy/swag-test
+docker compose -f docker-compose.dind.yaml up -d
+
+# Shell into DinD to inspect:
+docker exec -it dind-swag-test sh
+docker ps  # see SWAG + app
+
+# Access at http://localhost:8888
+```
+
+## Homelab LXC Deployment
+
+### Create LXC (Proxmox)
+
+```bash
+# Create Ubuntu LXC with Docker nesting enabled
+pct create 100 local:vztmpl/ubuntu-22.04-standard_22.04-1_amd64.tar.zst \
+  --hostname maxwells-wallet \
+  --memory 2048 \
+  --cores 2 \
+  --rootfs local-lvm:8 \
+  --net0 name=eth0,bridge=vmbr0,ip=dhcp \
+  --features nesting=1
+
+pct start 100
+```
+
+### Bootstrap (inside LXC)
+
+One-liner:
+```bash
+curl -fsSL https://raw.githubusercontent.com/poindexter12/maxwells-wallet/main/deploy/swag-test/lxc-bootstrap.sh | bash
+```
+
+Or manually:
+```bash
+git clone https://github.com/poindexter12/maxwells-wallet.git
+cd maxwells-wallet/deploy/swag-test
+./lxc-bootstrap.sh
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `Makefile` | Local make commands (up, down, cloudflare, etc.) |
+| `docker-compose.yaml` | SWAG + app stack |
+| `docker-compose.dind.yaml` | DinD wrapper for isolated testing |
+| `swag/nginx.conf` | NGINX reverse proxy config |
+| `lxc-bootstrap.sh` | LXC setup script (installs Docker, deploys stack) |
+| `.env.example` | Template for Cloudflare token |
+
+## Adding Cloudflare Tunnel
+
+```bash
+cd deploy/swag-test
+make cloudflare   # Prompts for token, then starts everything
+```
+
+Or manually:
+1. Create tunnel at [Cloudflare Zero Trust](https://one.dash.cloudflare.com/) → Networks → Tunnels
+2. Configure public hostname to point to: `http://swag:80`
+3. Save token: `echo "CLOUDFLARE_TUNNEL_TOKEN=your-token" > .env`
+4. Start: `make cloudflare`
+
+## Ports
+
+| Port | Service | Exposed |
+|------|---------|---------|
+| 8888 | SWAG HTTP | Yes |
+| 8443 | SWAG HTTPS | Yes |
+| 3000 | Frontend | Internal |
+| 3001 | Backend API | Internal |
+
+## Troubleshooting
+
+```bash
+# Check container status
+docker compose ps
+
+# View logs
+docker compose logs -f
+docker compose logs swag
+docker compose logs app
+
+# Restart
+docker compose restart
+
+# Full reset
+docker compose down -v
+docker compose up -d
+```

--- a/deploy/swag-test/docker-compose.dind.yaml
+++ b/deploy/swag-test/docker-compose.dind.yaml
@@ -1,0 +1,57 @@
+# Docker-in-Docker SWAG Demo Test Environment
+#
+# Runs a complete isolated Docker environment inside Docker,
+# then deploys SWAG + Maxwell's Wallet (demo mode) inside.
+# Simulates LXC deployment with nested Docker.
+#
+# Usage:
+#   cd deploy/swag-test
+#   docker compose -f docker-compose.dind.yaml up -d
+#
+#   # Shell into DinD to interact with inner Docker:
+#   docker exec -it dind-swag-test sh
+#   docker ps  # see SWAG + app running inside
+#
+#   # Access at http://localhost:8080
+#
+# Demo mode resets data every hour.
+
+services:
+  dind:
+    image: docker:27-dind
+    container_name: dind-swag-test
+    privileged: true
+    environment:
+      - DOCKER_TLS_CERTDIR=  # Disable TLS for simplicity in testing
+    volumes:
+      # Mount compose files and configs into DinD
+      - ./docker-compose.yaml:/workspace/docker-compose.yaml:ro
+      - ./swag:/workspace/swag:ro
+      # Persist DinD's docker data
+      - dind-data:/var/lib/docker
+    ports:
+      - "8080:8080"   # SWAG HTTP
+      - "8443:8443"   # SWAG HTTPS
+    entrypoint: |
+      sh -c '
+        # Start Docker daemon
+        dockerd-entrypoint.sh &
+
+        # Wait for Docker to be ready
+        echo "Waiting for Docker daemon..."
+        while ! docker info >/dev/null 2>&1; do
+          sleep 1
+        done
+        echo "Docker daemon ready!"
+
+        # Deploy the stack
+        cd /workspace
+        docker compose up -d
+
+        # Keep container running and tail logs
+        echo "Stack deployed! Tailing logs..."
+        docker compose logs -f
+      '
+
+volumes:
+  dind-data:

--- a/deploy/swag-test/docker-compose.yaml
+++ b/deploy/swag-test/docker-compose.yaml
@@ -1,0 +1,88 @@
+# SWAG Demo Deployment
+#
+# Maxwell's Wallet behind SWAG reverse proxy in demo mode.
+# Resets to sample data every hour.
+#
+# Usage:
+#   cd deploy/swag-test
+#   docker compose up -d
+#   # Access at http://localhost:8080
+#
+# For DinD testing (full isolation), use: docker-compose.dind.yaml
+
+services:
+  # SWAG - Secure Web Application Gateway (nginx-based reverse proxy)
+  swag:
+    image: lscr.io/linuxserver/swag:latest
+    container_name: swag
+    cap_add:
+      - NET_ADMIN
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      # For local testing, we skip SSL cert generation
+      - VALIDATION=http
+      - URL=localhost
+      - SUBDOMAINS=
+      - STAGING=true
+      - ONLY_SUBDOMAINS=false
+    volumes:
+      - ./swag/nginx.conf:/config/nginx/site-confs/default.conf:ro
+      - swag-config:/config
+    ports:
+      - "8888:80"
+      - "8443:443"
+    depends_on:
+      app:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # Maxwell's Wallet application (Demo Mode)
+  app:
+    # Use local build for ARM64 (Apple Silicon) or pull image for x86
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    image: maxwells-wallet:local
+    container_name: maxwells-wallet
+    volumes:
+      - wallet-data:/data
+    environment:
+      - DATABASE_URL=sqlite+aiosqlite:////data/wallet.db
+      # Demo mode - resets every hour with sample data
+      - DEMO_MODE=true
+      - DEMO_RESET_INTERVAL_HOURS=1
+      # Backup settings
+      - BACKUP_DIR=/data/backups
+      - BACKUP_RETENTION=5
+    # Not exposing ports directly - accessed through SWAG
+    expose:
+      - "3000"
+      - "3001"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # Cloudflare Tunnel (optional - for external access)
+  # Create tunnel at: https://one.dash.cloudflare.com/
+  # Set CLOUDFLARE_TUNNEL_TOKEN in .env file
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: cloudflared
+    command: tunnel run
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN:-}
+    depends_on:
+      - swag
+    restart: unless-stopped
+    profiles:
+      - cloudflare  # Only starts with: docker compose --profile cloudflare up -d
+
+volumes:
+  swag-config:
+  wallet-data:

--- a/deploy/swag-test/lxc-bootstrap.sh
+++ b/deploy/swag-test/lxc-bootstrap.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Bootstrap script for deploying Maxwell's Wallet DEMO in an LXC container
+#
+# Deploys a demo instance with:
+#   - SWAG reverse proxy
+#   - Sample data pre-seeded
+#   - Hourly data reset
+#
+# Prerequisites:
+#   - LXC with nesting enabled (for Docker support)
+#   - Ubuntu 22.04+ or Debian 12+
+#
+# Usage:
+#   # On Proxmox, create LXC with nesting:
+#   pct create 100 local:vztmpl/ubuntu-22.04-standard_22.04-1_amd64.tar.zst \
+#     --hostname maxwells-wallet \
+#     --memory 2048 \
+#     --cores 2 \
+#     --rootfs local-lvm:8 \
+#     --net0 name=eth0,bridge=vmbr0,ip=dhcp \
+#     --features nesting=1
+#
+#   # Then inside the LXC:
+#   curl -fsSL https://raw.githubusercontent.com/poindexter12/maxwells-wallet/main/deploy/swag-test/lxc-bootstrap.sh | bash
+#
+# Or clone and run:
+#   git clone https://github.com/poindexter12/maxwells-wallet.git
+#   cd maxwells-wallet/deploy/swag-test
+#   ./lxc-bootstrap.sh
+
+set -e
+
+echo "==> Maxwell's Wallet LXC Bootstrap"
+echo ""
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+# Install Docker if not present
+if ! command -v docker &> /dev/null; then
+  echo "==> Installing Docker..."
+  apt-get update
+  apt-get install -y ca-certificates curl gnupg
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod a+r /etc/apt/keyrings/docker.gpg
+
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+  apt-get update
+  apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  systemctl enable docker
+  systemctl start docker
+  echo "==> Docker installed!"
+else
+  echo "==> Docker already installed"
+fi
+
+# Create deployment directory
+DEPLOY_DIR="/opt/maxwells-wallet"
+mkdir -p "$DEPLOY_DIR"
+cd "$DEPLOY_DIR"
+
+# Download compose files if not present
+if [ ! -f "docker-compose.yaml" ]; then
+  echo "==> Downloading deployment files..."
+  BASE_URL="https://raw.githubusercontent.com/poindexter12/maxwells-wallet/main/deploy/swag-test"
+  curl -fsSL "$BASE_URL/docker-compose.yaml" -o docker-compose.yaml
+  mkdir -p swag
+  curl -fsSL "$BASE_URL/swag/nginx.conf" -o swag/nginx.conf
+fi
+
+# Create data directories
+mkdir -p data
+
+# Start the stack
+echo "==> Starting Maxwell's Wallet with SWAG..."
+docker compose up -d
+
+echo ""
+echo "==> Demo deployment complete!"
+echo ""
+echo "Access the app at: http://$(hostname -I | awk '{print $1}'):8080"
+echo ""
+echo "Demo mode is enabled:"
+echo "  - Sample data is pre-seeded"
+echo "  - Data resets every hour"
+echo "  - Destructive operations are blocked"
+echo ""
+echo "Useful commands:"
+echo "  docker compose logs -f    # View logs"
+echo "  docker compose restart    # Restart services"
+echo "  docker compose down       # Stop services"

--- a/deploy/swag-test/swag/nginx.conf
+++ b/deploy/swag-test/swag/nginx.conf
@@ -1,0 +1,68 @@
+# Maxwell's Wallet SWAG/nginx configuration
+#
+# Proxies all requests to the app container:
+# - / -> frontend (port 3000)
+# - /api/* -> backend (port 3001)
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    # For SSL (uncomment when using real certs):
+    # listen 443 ssl http2 default_server;
+    # listen [::]:443 ssl http2 default_server;
+    # include /config/nginx/ssl.conf;
+
+    server_name _;
+
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Backend API - proxy /api/* to port 3001
+    location /api/ {
+        proxy_pass http://app:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support (if needed)
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Timeouts
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # Frontend - proxy everything else to port 3000
+    location / {
+        proxy_pass http://app:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support for Next.js HMR (dev mode)
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Timeouts
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # Health check endpoint
+    location /health {
+        proxy_pass http://app:3001/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+}

--- a/deploy/swag-test/test_config.py
+++ b/deploy/swag-test/test_config.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Tests for SWAG demo deployment configuration.
+
+Run with: python -m pytest deploy/swag-test/test_config.py -v
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+DEPLOY_DIR = Path(__file__).parent
+
+
+class TestDockerCompose:
+    """Test docker-compose configuration files."""
+
+    def test_main_compose_is_valid_yaml(self):
+        """docker-compose.yaml should be valid YAML."""
+        compose_file = DEPLOY_DIR / "docker-compose.yaml"
+        assert compose_file.exists(), "docker-compose.yaml not found"
+
+        with open(compose_file) as f:
+            config = yaml.safe_load(f)
+
+        assert config is not None
+        assert "services" in config
+
+    def test_main_compose_has_required_services(self):
+        """docker-compose.yaml should define swag, app, and cloudflared services."""
+        compose_file = DEPLOY_DIR / "docker-compose.yaml"
+
+        with open(compose_file) as f:
+            config = yaml.safe_load(f)
+
+        services = config["services"]
+        assert "swag" in services, "Missing 'swag' service"
+        assert "app" in services, "Missing 'app' service"
+        assert "cloudflared" in services, "Missing 'cloudflared' service"
+
+    def test_app_service_has_demo_mode_enabled(self):
+        """App service should have DEMO_MODE=true."""
+        compose_file = DEPLOY_DIR / "docker-compose.yaml"
+
+        with open(compose_file) as f:
+            config = yaml.safe_load(f)
+
+        app_env = config["services"]["app"]["environment"]
+        assert "DEMO_MODE=true" in app_env, "DEMO_MODE should be true"
+
+    def test_app_service_has_hourly_reset(self):
+        """App service should reset every hour."""
+        compose_file = DEPLOY_DIR / "docker-compose.yaml"
+
+        with open(compose_file) as f:
+            config = yaml.safe_load(f)
+
+        app_env = config["services"]["app"]["environment"]
+        assert "DEMO_RESET_INTERVAL_HOURS=1" in app_env, "Should reset hourly"
+
+    def test_cloudflared_uses_profile(self):
+        """Cloudflared should only start with --profile cloudflare."""
+        compose_file = DEPLOY_DIR / "docker-compose.yaml"
+
+        with open(compose_file) as f:
+            config = yaml.safe_load(f)
+
+        cloudflared = config["services"]["cloudflared"]
+        assert "profiles" in cloudflared, "cloudflared should use profiles"
+        assert "cloudflare" in cloudflared["profiles"]
+
+    def test_swag_exposes_port_8888(self):
+        """SWAG should expose port 8888 for HTTP."""
+        compose_file = DEPLOY_DIR / "docker-compose.yaml"
+
+        with open(compose_file) as f:
+            config = yaml.safe_load(f)
+
+        swag_ports = config["services"]["swag"]["ports"]
+        port_mappings = [str(p) for p in swag_ports]
+        assert any("8888:80" in p for p in port_mappings), "Should expose 8888:80"
+
+    def test_dind_compose_is_valid_yaml(self):
+        """docker-compose.dind.yaml should be valid YAML."""
+        compose_file = DEPLOY_DIR / "docker-compose.dind.yaml"
+        assert compose_file.exists(), "docker-compose.dind.yaml not found"
+
+        with open(compose_file) as f:
+            config = yaml.safe_load(f)
+
+        assert config is not None
+        assert "services" in config
+        assert "dind" in config["services"]
+
+
+class TestNginxConfig:
+    """Test nginx configuration."""
+
+    def test_nginx_config_exists(self):
+        """nginx.conf should exist."""
+        nginx_conf = DEPLOY_DIR / "swag" / "nginx.conf"
+        assert nginx_conf.exists(), "swag/nginx.conf not found"
+
+    def test_nginx_config_has_api_location(self):
+        """nginx.conf should proxy /api/ to backend."""
+        nginx_conf = DEPLOY_DIR / "swag" / "nginx.conf"
+
+        content = nginx_conf.read_text()
+        assert "location /api/" in content, "Should have /api/ location block"
+        assert "proxy_pass http://app:3001" in content, "Should proxy to app:3001"
+
+    def test_nginx_config_has_frontend_location(self):
+        """nginx.conf should proxy / to frontend."""
+        nginx_conf = DEPLOY_DIR / "swag" / "nginx.conf"
+
+        content = nginx_conf.read_text()
+        assert "location /" in content, "Should have / location block"
+        assert "proxy_pass http://app:3000" in content, "Should proxy to app:3000"
+
+    def test_nginx_config_has_security_headers(self):
+        """nginx.conf should include security headers."""
+        nginx_conf = DEPLOY_DIR / "swag" / "nginx.conf"
+
+        content = nginx_conf.read_text()
+        assert "X-Content-Type-Options" in content
+        assert "X-Frame-Options" in content
+
+
+class TestMakefile:
+    """Test Makefile targets."""
+
+    def test_makefile_exists(self):
+        """Makefile should exist."""
+        makefile = DEPLOY_DIR / "Makefile"
+        assert makefile.exists(), "Makefile not found"
+
+    def test_makefile_has_required_targets(self):
+        """Makefile should have up, down, cloudflare, logs, clean targets."""
+        makefile = DEPLOY_DIR / "Makefile"
+
+        content = makefile.read_text()
+        required_targets = ["up:", "down:", "cloudflare:", "logs:", "clean:"]
+
+        for target in required_targets:
+            assert target in content, f"Missing target: {target}"
+
+    def test_makefile_has_help_as_default(self):
+        """Makefile should have help as default target."""
+        makefile = DEPLOY_DIR / "Makefile"
+
+        content = makefile.read_text()
+        assert ".DEFAULT_GOAL := help" in content
+
+
+class TestSupportingFiles:
+    """Test supporting files exist."""
+
+    def test_env_example_exists(self):
+        """.env.example should exist with CLOUDFLARE_TUNNEL_TOKEN."""
+        env_example = DEPLOY_DIR / ".env.example"
+        assert env_example.exists(), ".env.example not found"
+
+        content = env_example.read_text()
+        assert "CLOUDFLARE_TUNNEL_TOKEN" in content
+
+    def test_readme_exists(self):
+        """README.md should exist."""
+        readme = DEPLOY_DIR / "README.md"
+        assert readme.exists(), "README.md not found"
+
+    def test_gitignore_excludes_env(self):
+        """Root .gitignore should exclude deploy/swag-test/.env."""
+        gitignore = DEPLOY_DIR.parent.parent / ".gitignore"
+
+        content = gitignore.read_text()
+        assert "deploy/swag-test/.env" in content, ".env should be gitignored"


### PR DESCRIPTION
## Summary
- Add `deploy/swag-test/` directory for SWAG reverse proxy deployment
- Demo mode with hourly data reset
- Optional Cloudflare tunnel for external access
- Self-documenting Makefile
- 17 configuration tests

## Usage
```bash
cd deploy/swag-test
make up          # Local demo at http://localhost:8888
make cloudflare  # With Cloudflare tunnel
make test        # Run config tests
```

## Test plan
- [x] Local deployment works at localhost:8888
- [x] Cloudflare tunnel connects successfully
- [x] Demo mode resets data hourly
- [x] All 17 config tests pass