### PR TITLE
fix: sanitize scheduler log inputs to prevent log injection

### DIFF
--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -106,7 +106,7 @@ class SchedulerService:
             replace_existing=True,
             name="Automatic database backup",
         )
-        logger.info("Scheduled automatic backups every %d hours", interval_hours)
+        logger.info("Scheduled automatic backups every %d hours", int(interval_hours))
 
     def schedule_demo_reset(self, interval_hours: int) -> None:
         """Schedule demo mode data resets at the specified interval."""
@@ -121,7 +121,7 @@ class SchedulerService:
             replace_existing=True,
             name="Demo mode data reset",
         )
-        logger.info("Scheduled demo resets every %d hours", interval_hours)
+        logger.info("Scheduled demo resets every %d hours", int(interval_hours))
 
     def _remove_job(self, job_id: str) -> None:
         """Remove a scheduled job if it exists."""


### PR DESCRIPTION
## Summary
- Explicitly cast `interval_hours` to `int` before logging in `schedule_auto_backup()` and `schedule_demo_reset()` to prevent log injection
- Values are already validated by Pydantic, but CodeQL traces the data flow from the API endpoint and flags the raw path

## CodeQL Alerts Fixed
- [#75](https://github.com/poindexter12/maxwells-wallet/security/code-scanning/75) — `py/log-injection` at `scheduler.py:109`
- [#76](https://github.com/poindexter12/maxwells-wallet/security/code-scanning/76) — `py/log-injection` at `scheduler.py:124`

## Test plan
- [x] Backend tests pass (1130/1130)
- [ ] CI passes on this branch
- [ ] CodeQL rescan closes both alerts