### PR TITLE
ci: fix DAST artifact upload expecting default report filename

### DIFF
--- a/.github/workflows/dast.yaml
+++ b/.github/workflows/dast.yaml
@@ -63,7 +63,6 @@ jobs:
         with:
           target: 'http://localhost:3000'
           allow_issue_writing: false
-          artifact_name: 'zap-scan'
           fail_action: false
           cmd_options: '-J zap-report.json'
 


### PR DESCRIPTION
## Summary
- Remove `artifact_name: 'zap-scan'` from the ZAP baseline action step in the DAST workflow
- The action's built-in artifact upload looks for `report_json.json` (default), but `-J zap-report.json` writes the report under a custom name — causing the `File report_json.json does not exist` error
- The dedicated "Upload ZAP reports as artifacts" step already handles the correct filenames, so the built-in upload was redundant

## Test plan
- [ ] DAST workflow runs without the `report_json.json does not exist` error
- [ ] ZAP scan artifacts are still uploaded correctly via the dedicated upload step