### PR TITLE
ci: use ZAP action default report filename to fix DAST artifact upload

### DIFF
--- a/.github/workflows/dast.yaml
+++ b/.github/workflows/dast.yaml
@@ -64,20 +64,19 @@ jobs:
           target: 'http://localhost:3000'
           allow_issue_writing: false
           fail_action: false
-          cmd_options: '-J zap-report.json'
 
       - name: Sanitize ZAP SARIF output
-        if: always() && hashFiles('zap-report.json') != ''
+        if: always() && hashFiles('report_json.json') != ''
         run: |
           jq 'del(.["@programName"], .["@version"], .["@generated"], .insights)' \
-            zap-report.json > zap-report-clean.json
-          mv zap-report-clean.json zap-report.json
+            report_json.json > report_json_clean.json
+          mv report_json_clean.json report_json.json
 
       - name: Upload SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
-        if: always() && hashFiles('zap-report.json') != ''
+        if: always() && hashFiles('report_json.json') != ''
         with:
-          sarif_file: zap-report.json
+          sarif_file: report_json.json
           category: zap
 
       - name: Upload ZAP reports as artifacts
@@ -86,7 +85,7 @@ jobs:
         with:
           name: zap-reports
           path: |
-            zap-report.json
+            report_json.json
             report_html.html
             report_md.md
           retention-days: 30


### PR DESCRIPTION
## Summary
- The `zaproxy/action-baseline` always injects `-J report_json.json -w report_md.md -r report_html.html` into the ZAP command automatically
- Our `cmd_options: '-J zap-report.json'` was appended **after**, so ZAP saw two `-J` flags, honored only the last one, and `report_json.json` was never created
- The action's post-scan step then failed looking for `report_json.json`
- Fix: drop the custom `-J` flag entirely and update all downstream steps to reference `report_json.json` (the action's default)

Supersedes #219 which only removed `artifact_name` — the root cause was the duplicate `-J` flag.

## Test plan
- [ ] DAST workflow completes without `report_json.json does not exist` error
- [ ] ZAP SARIF report uploads to GitHub Security tab
- [ ] ZAP artifacts are uploaded correctly