### PR TITLE
ci: fix SARIF URI scheme for GitHub Code Scanning

### DIFF
--- a/.github/workflows/dast.yaml
+++ b/.github/workflows/dast.yaml
@@ -96,10 +96,12 @@ jobs:
                           elif $alert.riskcode == "2" then "warning"
                           elif $alert.riskcode == "1" then "note"
                           else "none" end),
-                "message": { "text": $alert.alert },
+                "message": { "text": ($alert.alert + " at " + .uri) },
                 "locations": [{
                   "physicalLocation": {
-                    "artifactLocation": { "uri": .uri }
+                    "artifactLocation": {
+                      "uri": (.uri | gsub("^https?://[^/]+/?"; "") | if . == "" then "index" else . end)
+                    }
                   }
                 }]
               }]


### PR DESCRIPTION
## Summary
- GitHub Code Scanning rejects SARIF with `http://` URIs — it expects relative file paths
- Strip scheme+host from ZAP URLs (`http://localhost:3000/setup` → `setup`)
- Preserve full URL in the result message text for context
- Root URL (`/`) maps to `index`

## Test plan
- [ ] DAST workflow completes without errors
- [ ] SARIF upload to GitHub Security tab succeeds
- [ ] ZAP findings visible in Security tab with URL context in messages