### PR TITLE
security: add HTTP security headers to fix ZAP DAST findings

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,7 @@ from app.routers import (
 )
 from app.observability import setup_observability
 from app.services.scheduler import scheduler_service
-from app.middleware import add_demo_mode_middleware
+from app.middleware import SecurityHeadersMiddleware, add_demo_mode_middleware
 from app.version import get_version, get_version_info
 
 
@@ -98,6 +98,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Security headers (defense-in-depth for direct backend access)
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Demo mode middleware (blocks restricted operations when DEMO_MODE=true)
 add_demo_mode_middleware(app)

--- a/backend/app/middleware/__init__.py
+++ b/backend/app/middleware/__init__.py
@@ -1,4 +1,5 @@
 # Middleware module
 from app.middleware.demo_mode import DemoModeMiddleware, add_demo_mode_middleware
+from app.middleware.security_headers import SecurityHeadersMiddleware
 
-__all__ = ["DemoModeMiddleware", "add_demo_mode_middleware"]
+__all__ = ["DemoModeMiddleware", "SecurityHeadersMiddleware", "add_demo_mode_middleware"]

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -1,0 +1,44 @@
+"""
+Security headers middleware for defense-in-depth.
+
+Adds standard security headers to all responses. Uses setdefault()
+so route-specific headers take precedence.
+"""
+
+from typing import Callable, cast
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# Headers applied to every response (won't override existing values)
+SECURITY_HEADERS: dict[str, str] = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Content-Security-Policy": (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data:; "
+        "connect-src 'self'; "
+        "frame-ancestors 'self'; "
+        "base-uri 'self'; "
+        "form-action 'self'"
+    ),
+    "Cache-Control": "no-store",
+}
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add security headers to all responses without overriding route-specific values."""
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        response = cast(Response, await call_next(request))
+        for header, value in SECURITY_HEADERS.items():
+            # setdefault: only add if the header isn't already set by the route
+            if header not in response.headers:
+                response.headers[header] = value
+        return response

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  poweredByHeader: false,
   async rewrites() {
     const backendUrl = process.env.BACKEND_URL || 'http://localhost:3001'
     return [
@@ -11,6 +12,76 @@ const nextConfig = {
       {
         source: '/metrics',
         destination: `${backendUrl}/metrics`,
+      },
+    ]
+  },
+  async headers() {
+    return [
+      {
+        // Apply security headers to all routes
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+              "font-src 'self' https://fonts.gstatic.com",
+              "img-src 'self' data:",
+              "connect-src 'self'",
+              "frame-ancestors 'self'",
+              "base-uri 'self'",
+              "form-action 'self'",
+            ].join('; '),
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=(), payment=()',
+          },
+          {
+            key: 'Cross-Origin-Resource-Policy',
+            value: 'same-origin',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+        ],
+      },
+      {
+        // Add Cache-Control: no-store to non-static routes
+        source: '/:path*',
+        has: [
+          {
+            type: 'header',
+            key: 'x-nextjs-data',
+          },
+        ],
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-store',
+          },
+        ],
+      },
+      {
+        // Cache-Control for HTML pages (not static assets)
+        source: '/((?!_next/static|_next/image|favicon.ico).*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-store',
+          },
+        ],
       },
     ]
   },


### PR DESCRIPTION
## Summary

- Adds HTTP security headers at the Next.js application layer (`next.config.js`) and as defense-in-depth on the FastAPI backend (`SecurityHeadersMiddleware`)
- Resolves **8 of 10** ZAP DAST alert categories (42 individual alerts) surfaced by the GitHub Security tab after #221/#222
- Remaining 2 alerts are false positives/informational (vendor JS suspicious comments, modern web app detection)

### Headers added

| Header | Purpose | ZAP Alert |
|---|---|---|
| `Content-Security-Policy` | Restrict resource loading origins | 10038 |
| `X-Frame-Options: DENY` | Prevent clickjacking | 10020 |
| `X-Content-Type-Options: nosniff` | Prevent MIME sniffing | 10021, 10019 |
| `Permissions-Policy` | Disable unused browser APIs | 10063 |
| `Cross-Origin-Resource-Policy: same-origin` | Prevent cross-origin resource reads | 90004 |
| `Referrer-Policy: strict-origin-when-cross-origin` | Limit referrer data leakage | bonus |
| `Cache-Control: no-store` | Prevent caching of dynamic pages | 10049 |
| `poweredByHeader: false` | Remove X-Powered-By header | 10037 |

### Files changed
- `frontend/next.config.js` — all frontend security headers + `poweredByHeader: false`
- `backend/app/middleware/security_headers.py` — new `SecurityHeadersMiddleware` (setdefault pattern)
- `backend/app/middleware/__init__.py` — export
- `backend/app/main.py` — register middleware after CORS

## Test plan
- [x] `make build-frontend` passes
- [x] `make test-backend` passes (1153 tests)
- [ ] `curl -I http://localhost:3000` — verify CSP, X-Frame-Options, X-Content-Type-Options, Permissions-Policy, CORP, Cache-Control present; X-Powered-By absent
- [ ] `curl -I http://localhost:3001/health` — verify backend security headers present
- [ ] Merge to main → DAST workflow runs → verify alert count drops from 42 to ~2–4 (suspicious comments + modern web app)