### PR TITLE
security: CSP nonces, COOP/COEP headers, robots/sitemap routes

### DIFF
--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -17,6 +17,8 @@ SECURITY_HEADERS: dict[str, str] = {
     "X-Frame-Options": "DENY",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
     "Cross-Origin-Resource-Policy": "same-origin",
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Embedder-Policy": "credentialless",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Content-Security-Policy": (
         "default-src 'self'; "

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -18,23 +18,9 @@ const nextConfig = {
   async headers() {
     return [
       {
-        // Apply security headers to all routes
+        // Security headers for all routes (CSP is set per-request in middleware.ts with nonces)
         source: '/:path*',
         headers: [
-          {
-            key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              "script-src 'self' 'unsafe-inline'",
-              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-              "font-src 'self' https://fonts.gstatic.com",
-              "img-src 'self' data:",
-              "connect-src 'self'",
-              "frame-ancestors 'self'",
-              "base-uri 'self'",
-              "form-action 'self'",
-            ].join('; '),
-          },
           {
             key: 'X-Frame-Options',
             value: 'DENY',
@@ -50,6 +36,14 @@ const nextConfig = {
           {
             key: 'Cross-Origin-Resource-Policy',
             value: 'same-origin',
+          },
+          {
+            key: 'Cross-Origin-Opener-Policy',
+            value: 'same-origin',
+          },
+          {
+            key: 'Cross-Origin-Embedder-Policy',
+            value: 'credentialless',
           },
           {
             key: 'Referrer-Policy',

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      disallow: '/',
+    },
+  }
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,5 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return []
+}


### PR DESCRIPTION
## Summary

Follow-up to #223. Addresses remaining fixable ZAP DAST alerts from GitHub Security tab.

- **CSP nonces** — Move CSP from static `next.config.js` to `middleware.ts` with per-request nonce generation. `script-src` uses `'nonce-xxx'` instead of `'unsafe-inline'`; Next.js auto-injects the nonce into its inline `<script>` tags. `style-src` retains `'unsafe-inline'` (required by Tailwind/Next.js inline styles).
- **COOP/COEP** — Add `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: credentialless` to both frontend and backend. `credentialless` avoids breaking Google Fonts cross-origin loads.
- **robots.ts + sitemap.ts** — Add Next.js metadata route handlers so `/robots.txt` and `/sitemap.xml` return proper responses with correct `Content-Type` instead of 404s. `Disallow: /` since this is a private finance app.

### Alert coverage

| ZAP Rule | Severity | Fix | Alerts |
|---|---|---|---|
| 10055 script-src unsafe-inline | WARNING | CSP nonce replaces unsafe-inline | 2 fixed |
| 90004 COOP/COEP missing | NOTE | Added both headers | 4 fixed |
| 10019 Content-Type missing | INFO | robots.ts + sitemap.ts route handlers | 2-3 fixed |

### Remaining (unfixable)
- **10055 style-src unsafe-inline** (2) — required by Tailwind CSS and Next.js inline styles
- **10027 suspicious comments** (4) — vendor JS bundles (Recharts, Next.js)
- **10109 modern web app** (2) — informational detection
- **10049 on `_next/static/*`** (5) — correctly cacheable immutable assets
- **Scorecard** (2) — repo age / code review process, not code issues

## Test plan
- [x] `make build-frontend` passes — `/robots.txt` and `/sitemap.xml` visible in route table
- [x] `make test-backend` passes (1153 tests)
- [ ] `curl -I http://localhost:3000` — verify CSP contains `nonce-` (not `unsafe-inline` for script-src), COOP/COEP present
- [ ] `curl http://localhost:3000/robots.txt` — verify `Content-Type: text/plain` and `Disallow: /`
- [ ] `curl http://localhost:3000/sitemap.xml` — verify `Content-Type: application/xml`
- [ ] Merge → DAST workflow → verify ~8-9 fewer open alerts