### PR TITLE
security: fix DAST scan quality — init app, bypass metadata routes

### DIFF
--- a/.github/workflows/dast.yaml
+++ b/.github/workflows/dast.yaml
@@ -58,6 +58,16 @@ jobs:
           docker compose -f docker-compose.dev.yaml logs
           exit 1
 
+      - name: Initialize application
+        run: |
+          # Create a test user so the app serves real pages instead of
+          # redirecting everything to /setup (302 without Content-Type)
+          curl -sf -X POST http://localhost:3001/api/v1/auth/setup \
+            -H 'Content-Type: application/json' \
+            -d '{"username": "dast-scanner", "password": "DastScan!2026"}' \
+            && echo "App initialized with test user" \
+            || echo "App initialization failed or already initialized"
+
       - name: Run ZAP baseline scan
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -10,8 +10,8 @@ import type { NextRequest } from 'next/server'
  * installs store tokens in localStorage, which middleware cannot access.
  */
 
-// Routes that skip middleware entirely (static assets, api, etc.)
-const BYPASS_ROUTES = ['/api', '/_next', '/favicon.ico', '/icon.svg']
+// Routes that skip middleware entirely (static assets, api, metadata files)
+const BYPASS_ROUTES = ['/api', '/_next', '/favicon.ico', '/icon.svg', '/robots.txt', '/sitemap.xml']
 
 function buildCsp(nonce: string): string {
   const isProd = process.env.NODE_ENV === 'production'
@@ -100,7 +100,8 @@ export const config = {
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico, icon.svg (favicon files)
+     * - robots.txt, sitemap.xml (metadata files served directly)
      */
-    '/((?!api|_next/static|_next/image|favicon.ico|icon.svg).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|icon.svg|robots.txt|sitemap.xml).*)',
   ],
 }


### PR DESCRIPTION
## Summary

Follow-up to #223 and #224. Fixes root causes of remaining Content-Type alerts and improves DAST scan coverage.

- **Initialize app before ZAP scan** — Creates a test user via `/api/v1/auth/setup` so ZAP scans actual pages instead of 302 redirects to `/setup`. Without this, every page request was a redirect (no Content-Type, no real page content scanned).
- **Bypass metadata routes in middleware** — Excludes `/robots.txt` and `/sitemap.xml` from the auth-check middleware so they serve directly from the Next.js route handlers with correct `Content-Type` headers.

### Expected alert reduction

| Rule | Current | After | Why |
|---|---|---|---|
| 10019 Content-Type Missing | 3 | 0 | App initialized → pages serve normally; metadata routes bypass middleware |

### Remaining open alerts (not suppressible via code)

| Rule | Sev | Count | Status |
|---|---|---|---|
| 10055 style-src unsafe-inline | WARN | 2 | Required by Tailwind/Next.js — no alternative to `'unsafe-inline'` for `style-src` |
| 10027 suspicious comments | INFO | 4 | License/attribution comments in vendor JS bundles — can't strip |
| 10049 storable/cacheable | INFO | ~10 | `_next/static/*` correctly cacheable (immutable); pages correctly non-storable |
| 10109 modern web app | INFO | 2 | Informational detection |
| Scorecard | HIGH | 2 | Repo age + review process — not code issues |

## Test plan
- [x] `make build-frontend` passes
- [x] `make test-backend` passes (1153 tests)
- [ ] Merge → DAST runs → 10019 alerts close
- [ ] Verify ZAP scans more pages (not just /setup redirects)