### PR TITLE
security: close remaining DAST alerts — CSP split, SARIF filter, branch protection

### DIFF
--- a/.github/workflows/dast.yaml
+++ b/.github/workflows/dast.yaml
@@ -78,6 +78,9 @@ jobs:
       - name: Convert ZAP JSON to SARIF
         if: always() && hashFiles('report_json.json') != ''
         run: |
+          # Convert ZAP JSON to SARIF, filtering out riskcode=0 (informational)
+          # alerts like caching behavior reports, framework detection, and vendor
+          # JS comment patterns. Raw ZAP reports (HTML/JSON/MD) still have everything.
           jq '{
             "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
             "version": "2.1.0",
@@ -86,7 +89,7 @@ jobs:
                 "driver": {
                   "name": "OWASP ZAP",
                   "informationUri": "https://www.zaproxy.org/",
-                  "rules": [.site[0].alerts[] | {
+                  "rules": [.site[0].alerts[] | select(.riskcode != "0") | {
                     "id": .pluginid,
                     "name": .alert,
                     "shortDescription": { "text": .alert },
@@ -94,18 +97,16 @@ jobs:
                     "defaultConfiguration": {
                       "level": (if .riskcode == "3" then "error"
                                 elif .riskcode == "2" then "warning"
-                                elif .riskcode == "1" then "note"
-                                else "none" end)
+                                else "note" end)
                     }
                   }]
                 }
               },
-              "results": [.site[0].alerts[] as $alert | $alert.instances[] | {
+              "results": [.site[0].alerts[] | select(.riskcode != "0") | . as $alert | .instances[] | {
                 "ruleId": $alert.pluginid,
                 "level": (if $alert.riskcode == "3" then "error"
                           elif $alert.riskcode == "2" then "warning"
-                          elif $alert.riskcode == "1" then "note"
-                          else "none" end),
+                          else "note" end),
                 "message": { "text": ($alert.alert + " at " + .uri) },
                 "locations": [{
                   "physicalLocation": {

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -23,7 +23,8 @@ SECURITY_HEADERS: dict[str, str] = {
     "Content-Security-Policy": (
         "default-src 'self'; "
         "script-src 'self' 'unsafe-inline'; "
-        "style-src 'self' 'unsafe-inline'; "
+        "style-src 'self'; "
+        "style-src-attr 'unsafe-inline'; "
         "img-src 'self' data:; "
         "connect-src 'self'; "
         "frame-ancestors 'self'; "

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -22,7 +22,8 @@ function buildCsp(nonce: string): string {
   return [
     "default-src 'self'",
     `script-src ${scriptSrc}`,
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "style-src 'self' https://fonts.googleapis.com",
+    "style-src-attr 'unsafe-inline'",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data:",
     "connect-src 'self'",


### PR DESCRIPTION
## Summary

Addresses all 22 remaining open security alerts. Follow-up to #223, #224, #225.

### 1. CSP style-src unsafe-inline → style-src-attr split (10055, 2 alerts)

CSP Level 3 lets us separate `style-src` (for `<style>` elements) from `style-src-attr` (for `style="..."` attributes):
- `style-src 'self' https://fonts.googleapis.com` — **no `'unsafe-inline'`**
- `style-src-attr 'unsafe-inline'` — allows React's `style={{}}` and Recharts SVG inline styles

ZAP rule 10055 checks `style-src` for `'unsafe-inline'` — it's gone. Confirmed zero `<style>` elements in the codebase (only 32 style *attribute* usages across 11 components).

### 2. SARIF pipeline: filter severity=none (10027/10049/10109, 18 alerts)

The SARIF conversion was uploading ALL ZAP output to Code Scanning, including `riskcode=0` informational reports:
- **10027** (6): "suspicious comments" in minified vendor JS — string literals matching `TODO`/`FIXME` regex
- **10049** (10): caching behavior reports — `_next/static/*` correctly cacheable, pages correctly non-storable
- **10109** (2): "modern web application" framework detection

These are not security findings. Now filtering `riskcode != "0"` in the jq conversion — only WARNING and NOTE alerts go to Code Scanning. **Raw ZAP reports (HTML/JSON/MD) uploaded as artifacts still contain everything.**

### 3. Branch protection: require PR reviews (Scorecard CodeReviewID, 1 alert)

- Set `required_approving_review_count: 1` and `dismiss_stale_reviews: true`
- `enforce_admins: false` — repo owner can still bypass when needed
- MaintainedID (1 alert): auto-resolves after repo passes 90-day age threshold

### Expected result after merge

| Category | Before | After |
|---|---|---|
| 10055 CSP style-src | 2 open | 0 |
| 10027 suspicious comments | 6 open | 0 (filtered from SARIF) |
| 10049 caching behavior | 10 open | 0 (filtered from SARIF) |
| 10109 modern web app | 2 open | 0 (filtered from SARIF) |
| CodeReviewID | 1 open | 0 (branch protection enabled) |
| MaintainedID | 1 open | 1 (auto-resolves with time) |
| **Total** | **22** | **≤1** |

## Test plan
- [x] `make build-frontend` passes
- [x] `make test-backend` passes (1153 tests)
- [x] Grep confirms 0 `<style>` elements, 32 `style={{}}` attributes (all safe with style-src-attr)
- [x] Branch protection updated (verified via API)
- [ ] Merge → DAST runs → verify Code Scanning alert count drops to ≤1