### PR TITLE
fix: restore backend test coverage to 90%

### DIFF
--- a/backend/tests/test_apply_alias.py
+++ b/backend/tests/test_apply_alias.py
@@ -1,0 +1,41 @@
+"""Unit tests for the apply_alias_to_text helper in merchants router."""
+
+from unittest.mock import MagicMock
+from app.routers.merchants import apply_alias_to_text
+from app.orm import MerchantAliasMatchType
+
+
+def _make_alias(pattern: str, match_type: MerchantAliasMatchType) -> MagicMock:
+    alias = MagicMock()
+    alias.pattern = pattern
+    alias.match_type = match_type
+    return alias
+
+
+class TestApplyAliasToText:
+    def test_empty_text_returns_false(self):
+        alias = _make_alias("AMZN", MerchantAliasMatchType.contains)
+        assert apply_alias_to_text(alias, "") is False
+
+    def test_none_text_returns_false(self):
+        alias = _make_alias("AMZN", MerchantAliasMatchType.contains)
+        assert apply_alias_to_text(alias, None) is False
+
+    def test_exact_match(self):
+        alias = _make_alias("Amazon", MerchantAliasMatchType.exact)
+        assert apply_alias_to_text(alias, "amazon") is True
+        assert apply_alias_to_text(alias, "Amazon Prime") is False
+
+    def test_contains_match(self):
+        alias = _make_alias("AMZN", MerchantAliasMatchType.contains)
+        assert apply_alias_to_text(alias, "AMZN MKTP US") is True
+        assert apply_alias_to_text(alias, "Target") is False
+
+    def test_regex_match(self):
+        alias = _make_alias(r"STARBUCKS.*\d+", MerchantAliasMatchType.regex)
+        assert apply_alias_to_text(alias, "STARBUCKS #1234") is True
+        assert apply_alias_to_text(alias, "Dunkin Donuts") is False
+
+    def test_regex_invalid_pattern_returns_false(self):
+        alias = _make_alias("[invalid(regex", MerchantAliasMatchType.regex)
+        assert apply_alias_to_text(alias, "anything") is False

--- a/backend/tests/test_merchants_comprehensive.py
+++ b/backend/tests/test_merchants_comprehensive.py
@@ -319,33 +319,30 @@ class TestAliasSuggestions:
     @pytest.mark.asyncio
     async def test_get_suggestions_empty(self, client: AsyncClient):
         """Get suggestions with no transactions"""
-        # Note: Route ordering may cause 422 if path variable matches first
         response = await client.get("/api/v1/merchants/aliases/suggestions")
-        # Accept 200 (success) or 422 (route ordering issue with path params)
-        if response.status_code == 200:
-            data = response.json()
-            assert "count" in data
-            assert "suggestions" in data
-            assert isinstance(data["suggestions"], list)
+        assert response.status_code == 200
+        data = response.json()
+        assert "count" in data
+        assert "suggestions" in data
+        assert isinstance(data["suggestions"], list)
 
     @pytest.mark.asyncio
     async def test_get_suggestions_with_data(self, client: AsyncClient, seed_transactions):
         """Get suggestions with existing transactions"""
         response = await client.get("/api/v1/merchants/aliases/suggestions")
-        if response.status_code == 200:
-            data = response.json()
-            assert "count" in data
-            assert "suggestions" in data
+        assert response.status_code == 200
+        data = response.json()
+        assert "count" in data
+        assert "suggestions" in data
 
     @pytest.mark.asyncio
     async def test_get_suggestions_min_count(self, client: AsyncClient, seed_transactions):
         """Get suggestions with custom min_count"""
         response = await client.get("/api/v1/merchants/aliases/suggestions?min_count=1")
-        # Route may or may not work due to path ordering
-        assert response.status_code in [200, 422]
+        assert response.status_code == 200
 
         response2 = await client.get("/api/v1/merchants/aliases/suggestions?min_count=10")
-        assert response2.status_code in [200, 422]
+        assert response2.status_code == 200
 
     @pytest.mark.asyncio
     async def test_suggestions_exclude_existing_aliases(self, client: AsyncClient, seed_transactions):
@@ -361,10 +358,10 @@ class TestAliasSuggestions:
 
         # Get suggestions - should not include aliased pattern
         response = await client.get("/api/v1/merchants/aliases/suggestions")
-        if response.status_code == 200:
-            data = response.json()
-            for s in data["suggestions"]:
-                assert "EXCLUDE_FROM_SUGGESTIONS" not in (s.get("raw_merchant") or "").upper()
+        assert response.status_code == 200
+        data = response.json()
+        for s in data["suggestions"]:
+            assert "EXCLUDE_FROM_SUGGESTIONS" not in (s.get("raw_merchant") or "").upper()
 
 
 class TestAliasMatchTypes:

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -1,0 +1,71 @@
+"""Tests for app/version.py — version reading logic."""
+
+import os
+import pytest
+from unittest.mock import patch
+from app.version import get_version, get_git_sha, get_version_info
+
+
+@pytest.fixture(autouse=True)
+def clear_lru_caches():
+    """Clear lru_cache between tests so each test starts fresh."""
+    get_version.cache_clear()
+    get_git_sha.cache_clear()
+    get_version_info.cache_clear()
+    yield
+    get_version.cache_clear()
+    get_git_sha.cache_clear()
+    get_version_info.cache_clear()
+
+
+class TestGetVersion:
+    def test_version_from_env(self):
+        """APP_VERSION env var takes priority."""
+        with patch.dict(os.environ, {"APP_VERSION": "1.2.3"}):
+            assert get_version() == "1.2.3"
+
+    def test_version_from_pyproject(self):
+        """Falls back to pyproject.toml when no env var."""
+        env = os.environ.copy()
+        env.pop("APP_VERSION", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = get_version()
+            # Should find the real pyproject.toml in this repo
+            assert isinstance(result, str)
+            assert len(result) > 0
+
+    def test_version_fallback_unknown(self):
+        """Returns 'unknown' when both env and pyproject fail."""
+        env = os.environ.copy()
+        env.pop("APP_VERSION", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch("builtins.open", side_effect=Exception("no file")):
+                assert get_version() == "unknown"
+
+
+class TestGetGitSha:
+    def test_git_sha_from_env(self):
+        with patch.dict(os.environ, {"GIT_SHA": "abc1234"}):
+            assert get_git_sha() == "abc1234"
+
+    def test_git_sha_not_set(self):
+        env = os.environ.copy()
+        env.pop("GIT_SHA", None)
+        with patch.dict(os.environ, env, clear=True):
+            assert get_git_sha() is None
+
+
+class TestGetVersionInfo:
+    def test_version_info_with_sha(self):
+        with patch.dict(os.environ, {"APP_VERSION": "2.0.0", "GIT_SHA": "deadbeef"}):
+            info = get_version_info()
+            assert info["version"] == "2.0.0"
+            assert info["git_sha"] == "deadbeef"
+
+    def test_version_info_without_sha(self):
+        env = os.environ.copy()
+        env.pop("GIT_SHA", None)
+        with patch.dict(os.environ, {**env, "APP_VERSION": "2.0.0"}, clear=True):
+            info = get_version_info()
+            assert info["version"] == "2.0.0"
+            assert "git_sha" not in info


### PR DESCRIPTION
## Summary

- **Fix unreachable route**: `/aliases/suggestions` was shadowed by `/aliases/{alias_id}` due to FastAPI route ordering — moved it above the path-param route
- **Add missing tests**: `version.py` (0→100%), `apply_alias_to_text` unit tests, auth `test_reset_users` endpoint, malformed auth header edge case
- **Strengthen existing tests**: merchant suggestion tests now assert `200` instead of accepting `200|422`

**Coverage: 89% → 90%** (626 missed lines, down from 667)

## Test plan

- [x] All 1174 backend tests pass
- [x] Coverage at 90% (`just test::coverage`)
- [x] `/aliases/suggestions` endpoint now reachable (was returning 422)
- [x] No behavioral changes to existing endpoints