### PR TITLE
fix(ci): stop nightly OWASP Dependency-Check from timing out

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -109,14 +109,25 @@ jobs:
         run: uv pip compile backend/pyproject.toml -o backend/requirements.txt
 
       - name: Run OWASP Dependency-Check scan
-        timeout-minutes: 12
+        timeout-minutes: 25
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
-          NVD_FLAG=""
-          if [ -n "$NVD_API_KEY" ]; then
-            NVD_FLAG="--nvdApiKey $NVD_API_KEY"
+          echo "## OWASP Dependency-Check" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Without an NVD API key the scanner is rate-limited (1 req/6s) and
+          # reliably exceeds any reasonable timeout. Skip cleanly so nightly
+          # runs aren't permanently red — README documents key setup.
+          if [ -z "$NVD_API_KEY" ]; then
+            echo "::warning::NVD_API_KEY secret not configured — skipping OWASP Dependency-Check scan."
+            echo "⏭️ Skipped — \`NVD_API_KEY\` secret not configured." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Without an NVD API key, the scanner is rate-limited and cannot complete in a reasonable time." >> $GITHUB_STEP_SUMMARY
+            echo "See [README](../blob/main/README.md) for setup instructions." >> $GITHUB_STEP_SUMMARY
+            exit 0
           fi
+
           mkdir -p reports
           docker run --rm \
             -v $(pwd):/src \
@@ -128,7 +139,7 @@ jobs:
             --format HTML \
             --out /src/reports \
             --project "Maxwell's Wallet" \
-            $NVD_FLAG \
+            --nvdApiKey "$NVD_API_KEY" \
             --enableExperimental
 
       - name: Upload SARIF to GitHub Security tab

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ Maxwell's Wallet uses five automated security scanning tools that run in CI and 
 
 **Optional Setup:**
 
-For faster Dependency-Check scans, configure an NVD API key (free from NVD):
+To enable Dependency-Check scans, configure an NVD API key (free from NVD):
 ```
 gh secret set NVD_API_KEY --body "your-api-key-here"
 ```
-Without the API key, Dependency-Check still works but may hit rate limits on large scans.
+Without the API key, the Dependency-Check job is skipped — NVD's unauthenticated rate limit (1 request / 6 seconds) makes the scan impractical to run in CI. Other security scans (pip-audit, Semgrep, CodeQL) run regardless.
 
 **Philosophy:** All security scans are **non-blocking** — they inform but never block development.
 


### PR DESCRIPTION
## Summary

The `OWASP Dependency-Check` job in the nightly `Security Scans` workflow has been **failing every night for 10+ consecutive runs**, consistently timing out at exactly the 12-minute limit. The overall `Nightly Code Quality` workflow appeared green only because the job is marked `continue-on-error: true` — but the underlying scan never actually completed.

### Root cause

Without an `NVD_API_KEY` secret, the scanner hits NVD's unauthenticated rate limit (1 request / 6 seconds) and cannot complete its database sync inside the 12-minute window. The README documented `NVD_API_KEY` as "optional with graceful degradation," but in practice the scan just timed out reliably instead of skipping.

### Changes

- **`.github/workflows/security.yaml`**
  - Skip the scan cleanly with an informative `$GITHUB_STEP_SUMMARY` message and `::warning::` when `NVD_API_KEY` is not configured — matches the README's stated "graceful degradation."
  - Bump scan `timeout-minutes` from 12 → 25 to give headroom for slow NVD responses when the key *is* configured.
  - Drop the now-unused `NVD_FLAG` shell variable; pass `--nvdApiKey` directly.
- **`README.md`**
  - Update the NVD API key section to reflect that the scan is now skipped (not just slow) without a key.

### Evidence

Most recent 10 nightly runs (`#150`–`#159`) all sat at exactly 12m 39s–46s — the timeout duration. Run #159 job breakdown:

| Job | Status |
|---|---|
| Security Audit (pip-audit) | ✅ |
| Dead Code Analysis (Vulture) | ✅ |
| Code Quality Checks | ✅ |
| Coverage Threshold Check | ✅ |
| Semgrep SAST | ✅ |
| **OWASP Dependency-Check** | **❌ Timed out (12m 37s)** |

## Test plan

- [ ] Trigger the `Nightly Code Quality` workflow manually via `workflow_dispatch` on this branch
- [ ] Confirm the OWASP Dependency-Check step exits cleanly (status: success) with the "Skipped — NVD_API_KEY not configured" message in the job summary (assuming the secret is unset)
- [ ] If `NVD_API_KEY` is configured, confirm the scan completes within 25 minutes and uploads the SARIF report
- [ ] Verify other security jobs (Semgrep, pip-audit, etc.) are unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJZYVbFGqQSbiwLCMDyNc5)_