### PR TITLE
fix(observability): replace deprecated asyncio.iscoroutinefunction

### DIFF
--- a/backend/app/observability/tracing.py
+++ b/backend/app/observability/tracing.py
@@ -5,7 +5,7 @@ Provides automatic instrumentation for FastAPI and SQLAlchemy,
 plus decorators for adding custom spans to business logic.
 """
 
-import asyncio
+import inspect
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
@@ -144,7 +144,7 @@ def traced(span_name: str | None = None) -> Callable[[F], F]:
                     span.set_status(trace.StatusCode.ERROR, str(e))
                     raise
 
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             return async_wrapper  # type: ignore[return-value]
         return sync_wrapper  # type: ignore[return-value]
 


### PR DESCRIPTION
## Why
`asyncio.iscoroutinefunction` is deprecated and slated for removal in **Python 3.16** (warning surfaced now that we're on 3.14).

## What
`app/observability/tracing.py`: use `inspect.iscoroutinefunction` (the recommended replacement) and drop the now-unused `asyncio` import. Only occurrence in the backend.

## Verified
ruff clean, mypy clean, 17 observability tests pass, deprecation warning gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)