### PR TITLE
fix(i18n): replace orphaned Crowdin App sync with pinned GitHub Action

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -1,0 +1,83 @@
+name: Crowdin Sync
+
+# Replaces the opaque Crowdin GitHub *App* integration with the Crowdin GitHub
+# *Action*, so localization sync runs inside our own CI where it is visible,
+# pinned, and debuggable.
+#
+#   - On push to main that touches en-US.json (the only source file), we push
+#     the updated source strings up to Crowdin.
+#   - On a weekly schedule (and on-demand via "Run workflow"), we pull completed
+#     translations down and open a PR onto main.
+#
+# Config (file mapping, project id) lives in crowdin.yaml at the repo root.
+# Secret: CROWDIN_PERSONAL_TOKEN (already set in repo secrets).
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/src/messages/en-US.json
+      - crowdin.yaml
+  schedule:
+    # Mondays 06:00 UTC — pull whatever translations are ready and open a PR.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    # Manual trigger. Use this for the first sync after enabling the Action.
+    inputs:
+      download:
+        description: "Download translations and open a PR (in addition to uploading sources)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Never let two syncs race each other against the same Crowdin project.
+concurrency:
+  group: crowdin-sync
+  cancel-in-progress: false
+
+jobs:
+  crowdin:
+    name: Crowdin Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # Push only: a source string changed on main. Don't open a PR here —
+      # there may be no new translations yet.
+      - name: Upload sources to Crowdin
+        if: github.event_name == 'push'
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2
+        with:
+          config: crowdin.yaml
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+        env:
+          CROWDIN_PROJECT_ID: "854226"
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      # Pull translations and open a PR onto main. Runs on the weekly schedule
+      # and on manual dispatch. The Action recreates the l10n/crowdin branch
+      # fresh from main each run, so it cannot drift the way the old App branch did.
+      - name: Download translations and open PR
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.download)
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2
+        with:
+          config: crowdin.yaml
+          upload_sources: true
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n/crowdin
+          create_pull_request: true
+          pull_request_base_branch_name: main
+          pull_request_title: "chore(i18n): sync translations from Crowdin"
+          pull_request_body: "Automated translation sync from Crowdin. Source strings (en-US.json) are never modified here."
+          pull_request_labels: "i18n,automated"
+          commit_message: "chore(i18n): sync translations from Crowdin"
+        env:
+          CROWDIN_PROJECT_ID: "854226"
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/docs/i18n-workflow.md
+++ b/docs/i18n-workflow.md
@@ -228,16 +228,16 @@ files:
 
 ### GitHub Integration
 
-Sync runs through the **Crowdin GitHub Action** (`.github/workflows/crowdin.yaml`), not the Crowdin GitHub App. The Action:
+Sync runs through the **Crowdin GitHub Action** (`.github/workflows/crowdin.yaml`). It replaces Crowdin's older **webhook/OAuth integration** — the one that authenticated as a repo user (so its commits/PRs showed up under a human account, not a `crowdin[bot]`) and silently orphaned the `i18n/crowdin-sync` branch after a history rewrite. That integration has been disconnected. The Action:
 - **Push to `main`** touching `en-US.json` → uploads source strings to Crowdin.
 - **Weekly schedule + manual dispatch** → downloads translations and opens a PR from `l10n/crowdin` → `main`.
-- Recreates `l10n/crowdin` fresh from `main` each run, so it can't silently drift from history rewrites (the failure that orphaned the old `i18n/crowdin-sync` branch).
+- Recreates `l10n/crowdin` fresh from `main` each run, so it can't silently drift from history rewrites.
 
 Requirements:
 - Repo secret `CROWDIN_PERSONAL_TOKEN` (already set).
 - Project ID `854226` lives in `crowdin.yaml`.
 
-> **Do not also enable the Crowdin GitHub App.** Running both the App and the Action against the same project causes duplicate/competing PRs. If the App is still connected in Crowdin (Project → Settings → Integrations → GitHub), disconnect it.
+> **Do not reconnect Crowdin's native GitHub integration** (Project → Settings → Integrations → GitHub). Running it alongside the Action against the same project causes duplicate/competing PRs and re-introduces the branch-drift failure. The Action is the only sync path.
 
 ## Troubleshooting
 

--- a/docs/i18n-workflow.md
+++ b/docs/i18n-workflow.md
@@ -84,13 +84,13 @@ git commit -m "feat: add myFeature translations"
 git push origin main
 ```
 
-### Step 4: Crowdin Syncs Automatically
+### Step 4: CI Uploads Sources to Crowdin
 
-Crowdin watches the `main` branch via GitHub integration. Within an hour (or on next sync), new strings appear in Crowdin for translators.
+The **Crowdin Sync** GitHub Action (`.github/workflows/crowdin.yaml`) runs on every push to `main` that changes `en-US.json` and uploads the new source strings to Crowdin. Watch it in the **Actions** tab — unlike the old GitHub App, every sync is visible and debuggable.
 
 ### Step 5: Translations Arrive via PR
 
-When translations are complete, Crowdin creates a PR from `i18n/crowdin-sync` → `main`. Review and merge it.
+The same workflow runs weekly (Mondays 06:00 UTC) and on-demand via **Actions → Crowdin Sync → Run workflow**. It downloads completed translations and opens a PR from `l10n/crowdin` → `main`. Review and merge it.
 
 ## String Key Conventions
 
@@ -144,36 +144,24 @@ git push
 
 ### Normal Flow
 
-1. Crowdin creates PR from `i18n/crowdin-sync` → `main`
+1. The Crowdin Sync workflow opens a PR from `l10n/crowdin` → `main`
 2. CI runs (skips E2E for translation-only changes)
 3. Review the changes (spot check a few strings)
 4. Merge the PR
 
 ### If There Are Conflicts
 
-Conflicts occur when `main` has changes Crowdin doesn't know about (usually from incorrect direct edits).
+Conflicts occur when `main` has changes Crowdin doesn't know about (usually from incorrect direct edits). Because the Action recreates `l10n/crowdin` from `main` on each run, the simplest fix is almost always to discard the branch and re-run the workflow:
 
-**Option A: Rebase**
 ```bash
-git fetch origin
-git checkout i18n/crowdin-sync
-git rebase origin/main
-# Resolve conflicts:
-# - For en-US.json: keep main's version
-# - For other locales: keep Crowdin's version (incoming)
-git push --force-with-lease
-```
-
-**Option B: Reset**
-```bash
-# Close the conflicted PR
+# Close the conflicted PR and delete the branch
 gh pr close <PR-number>
+git push origin --delete l10n/crowdin
 
-# Delete the branch
-git push origin --delete i18n/crowdin-sync
-
-# Crowdin will recreate it on next sync
+# Re-run: Actions → Crowdin Sync → Run workflow (download = true)
 ```
+
+If you must keep the branch, rebase it on `main` — keep `main`'s version of `en-US.json`, keep Crowdin's (incoming) version of every other locale — then `git push --force-with-lease`.
 
 ## Providing Context for Translators
 
@@ -240,17 +228,23 @@ files:
 
 ### GitHub Integration
 
-Crowdin uses the GitHub App integration (not a workflow file):
-- Watches: `main` branch
-- Creates: `i18n/crowdin-sync` branch
-- Auto-syncs: ~hourly
+Sync runs through the **Crowdin GitHub Action** (`.github/workflows/crowdin.yaml`), not the Crowdin GitHub App. The Action:
+- **Push to `main`** touching `en-US.json` → uploads source strings to Crowdin.
+- **Weekly schedule + manual dispatch** → downloads translations and opens a PR from `l10n/crowdin` → `main`.
+- Recreates `l10n/crowdin` fresh from `main` each run, so it can't silently drift from history rewrites (the failure that orphaned the old `i18n/crowdin-sync` branch).
+
+Requirements:
+- Repo secret `CROWDIN_PERSONAL_TOKEN` (already set).
+- Project ID `854226` lives in `crowdin.yaml`.
+
+> **Do not also enable the Crowdin GitHub App.** Running both the App and the Action against the same project causes duplicate/competing PRs. If the App is still connected in Crowdin (Project → Settings → Integrations → GitHub), disconnect it.
 
 ## Troubleshooting
 
 ### "My new strings aren't in Crowdin"
 
 1. Verify strings are in `en-US.json` and pushed to `main`
-2. Wait for auto-sync (~1 hour) or run `just i18n::upload`
+2. Check the **Crowdin Sync** run in the Actions tab (it triggers on push to `main`), or run `just i18n::upload` locally
 3. Check Crowdin project for the strings
 
 ### "Translations aren't appearing in the app"


### PR DESCRIPTION
## Problem

Crowdin's native **webhook/OAuth GitHub integration** (not a GitHub App — it authenticated as a repo user, so its commits/PRs appeared under a human account with no `crowdin[bot]`) cut its service branch (`i18n/crowdin-sync`) and silently orphaned it after `main` was squashed/rewritten. Consequences:

- **PR #184** ("New Crowdin updates") diverged at the 2nd commit ever (2025-11-22) and carried ~102k spurious additions across unrelated files — unmergeable. *(Now closed; branch deleted.)*
- **No translations have landed since 2025-12-12.** Every locale is **68 keys behind** `en-US.json` (Afar: 96). Strings like "Split transaction", "Clear all", and much of the Tools pages silently fall back to English in all non-English UIs.
- The failure was invisible because that integration ran outside CI.

## Fix

Replace the webhook/OAuth integration with the **Crowdin GitHub Action**, pinned to `v2.16.2` (`8868a335…`) like our other actions:

| Trigger | Action |
|---|---|
| Push to `main` touching `en-US.json` | Upload source strings to Crowdin |
| Weekly (Mon 06:00 UTC) + manual dispatch | Download translations, open PR `l10n/crowdin` → `main` |

The Action recreates `l10n/crowdin` from `main` each run, so it **cannot drift** into the orphaned state that broke PR #184. Sync now runs in CI where it's visible and debuggable.

## Crowdin-side change (done)

The native webhook/OAuth integration has been **disconnected in Crowdin** (webhook `585842238` removed) so it can't compete with the Action.

## Required manual step after merge

- **First sync:** Actions → *Crowdin Sync* → **Run workflow** — opens the first PR closing the 68-key gap.
- *(Optional)* Enable Crowdin MT pre-translation (no human translator community today).

## Follow-up

`i18n.test.ts` currently only checks `pseudo` completeness (line 104 explicitly skips real locales) — which is why the 68-key drift never turned CI red. Once the first sync PR closes the gap, enforce locale completeness so future drift fails loudly. Held back here to avoid red CI against the existing gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)