### PR TITLE
fix(i18n): pass GITHUB_TOKEN to Crowdin Action

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -81,3 +81,5 @@ jobs:
         env:
           CROWDIN_PROJECT_ID: "854226"
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          # Required for the Action to push l10n/crowdin and open the PR.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
First `Crowdin Sync` run (#26371229009) uploaded sources and downloaded all 8 locales successfully, then failed at PR creation:

```
ERROR: Either 'GITHUB_TOKEN' or 'GH_TOKEN' must be set in the environment variables!
```

The action needs `GITHUB_TOKEN` in env to push `l10n/crowdin` and open the PR. The workflow already declares `contents: write` + `pull-requests: write`. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)