### PR TITLE
chore(i18n): harden translation pipeline + ship aa-ER locale

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -83,3 +83,32 @@ jobs:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           # Required for the Action to push l10n/crowdin and open the PR.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Make unattended failures loud. A scheduled/push sync that fails silently is
+  # exactly how the old integration rotted for 5 months. Manual (workflow_dispatch)
+  # runs are skipped here since whoever triggered them already sees the result.
+  notify-failure:
+    name: Report sync failure
+    needs: crowdin
+    if: failure() && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update a tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create crowdin-sync-failure --color B60205 \
+            --description "Crowdin Sync workflow failed" --force --repo "$GITHUB_REPOSITORY" || true
+          body=$(printf 'The scheduled `Crowdin Sync` workflow failed — translations are not syncing.\n\nFailed run: %s\n\nSee docs/i18n-workflow.md. This issue gets a new comment on each subsequent failure; close it once a run succeeds.' "$RUN_URL")
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --label crowdin-sync-failure --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Crowdin Sync workflow failed" \
+              --label crowdin-sync-failure --body "$body"
+          fi

--- a/.github/workflows/i18n-guard.yaml
+++ b/.github/workflows/i18n-guard.yaml
@@ -1,0 +1,42 @@
+name: i18n Source Guard
+
+# Enforces the golden rule: only en-US.json is hand-edited. Every other
+# messages/*.json is managed by Crowdin (branch l10n/crowdin); editing one by
+# hand causes drift and merge conflicts. Developer-editable files are exempt:
+# en-US.json (source), pseudo.json (generated), universal.json + schema.json
+# (the validation allowlist). The Crowdin Sync PR is exempt by branch name.
+
+"on":
+  pull_request:
+    branches:
+      - main
+    paths:
+      - frontend/src/messages/**
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: No hand-edited locale files
+    if: github.head_ref != 'l10n/crowdin'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+      - name: Check changed locale files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA" HEAD -- 'frontend/src/messages/')
+          violations=$(printf '%s\n' "$changed" \
+            | grep -E '^frontend/src/messages/.+\.json$' \
+            | grep -vE '^frontend/src/messages/(en-US|pseudo|universal|schema)\.json$' || true)
+          if [ -n "$violations" ]; then
+            echo "::error::Translations are managed by Crowdin — only edit en-US.json. These Crowdin-managed locale files were hand-edited:"
+            printf '%s\n' "$violations"
+            echo "Revert them and put your strings in en-US.json instead. See docs/i18n-workflow.md."
+            exit 1
+          fi
+          echo "OK — no hand-edited Crowdin-managed locale files."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to AI coding agents when working with code in this r
 - **Backend**: FastAPI + Python (async)
 - **Database**: SQLite (dev) with SQLModel ORM (Postgres-ready for prod)
 - **Package Management**: npm (frontend), uv (backend)
-- **i18n**: next-intl with 9 locales (en-US, en-GB, es-ES, fr-FR, it-IT, pt-PT, de-DE, nl-NL, pseudo)
+- **i18n**: next-intl with 10 locales (en-US, en-GB, es-ES, fr-FR, it-IT, pt-PT, de-DE, nl-NL, aa-ER, pseudo)
 
 ## Repository Structure
 

--- a/backend/app/orm.py
+++ b/backend/app/orm.py
@@ -115,6 +115,7 @@ class LanguagePreference(str, Enum):
     pt_pt = "pt-PT"
     de_de = "de-DE"
     nl_nl = "nl-NL"
+    aa_er = "aa-ER"
     pseudo = "pseudo"
 
 

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -25,7 +25,7 @@ class BackupScheduleUpdate(BaseModel):
 router = APIRouter(prefix="/api/v1/settings", tags=["settings"])
 
 # Supported locales for i18n (BCP 47 codes)
-SUPPORTED_LOCALES = ["en-US", "en-GB", "es-ES", "fr-FR", "it-IT", "pt-PT", "de-DE", "nl-NL", "pseudo"]
+SUPPORTED_LOCALES = ["en-US", "en-GB", "es-ES", "fr-FR", "it-IT", "pt-PT", "de-DE", "nl-NL", "aa-ER", "pseudo"]
 DEFAULT_LOCALE = "en-US"
 
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -24,6 +24,7 @@ class TestSettingsEndpoints:
             "pt-PT",
             "de-DE",
             "nl-NL",
+            "aa-ER",
             "pseudo",
         ]
         assert "supported_locales" in data
@@ -44,6 +45,7 @@ class TestSettingsEndpoints:
             "pt-PT",
             "de-DE",
             "nl-NL",
+            "aa-ER",
             "pseudo",
         }
 

--- a/docs/i18n-workflow.md
+++ b/docs/i18n-workflow.md
@@ -210,6 +210,19 @@ just i18n::pseudo
 
 Enable in the app by selecting "Pseudo" in language settings.
 
+## CI Safety Gates
+
+These checks make i18n problems loud instead of silent (the prior setup drifted for months unnoticed):
+
+| Gate | Where | Catches |
+|------|-------|---------|
+| **Locale completeness** | `frontend/src/test/i18n.test.ts` | Any shipped locale missing a key from `en-US.json`. Runs in the Frontend CI job. |
+| **Placeholder integrity** | `frontend/src/test/i18n.test.ts` | A translation that drops/renames an ICU `{placeholder}` (a render-time crash). |
+| **Source guard** | `.github/workflows/i18n-guard.yaml` | A PR that hand-edits a Crowdin-managed locale file (everything except `en-US`, `pseudo`, `universal`, `schema`). The `l10n/crowdin` PR is exempt. |
+| **Notify on failure** | `.github/workflows/crowdin.yaml` | A scheduled/push sync that fails — opens/updates a `crowdin-sync-failure` issue instead of failing into the void. |
+
+The shipped locale set is defined once in `frontend/src/i18n.ts` (`productionLocales`) and must match the backend's `SUPPORTED_LOCALES` (`backend/app/routers/settings.py`) and `LanguagePreference` enum (`backend/app/orm.py`).
+
 ## Configuration
 
 ### Crowdin Config (`crowdin.yaml`)

--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -26,6 +26,7 @@ const dateFnsLocales: Record<string, DateFnsLocale> = {
   'pt-PT': pt,
   'de-DE': de,
   'nl-NL': nl,
+  'aa-ER': enUS, // date-fns has no Afar locale; fall back to en-US formatting
   'pseudo': enUS, // Fallback for pseudo locale
 }
 
@@ -39,6 +40,7 @@ const dateFormats: Record<string, string> = {
   'pt-PT': 'dd/MM/yyyy',
   'de-DE': 'dd.MM.yyyy',
   'nl-NL': 'dd-MM-yyyy',
+  'aa-ER': 'dd/MM/yyyy',
   'pseudo': 'MM/dd/yyyy',
 }
 

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,7 +1,7 @@
 /**
  * Internationalization (i18n) configuration for Maxwell's Wallet
  *
- * Supports 8 languages:
+ * Supports 9 languages:
  * - en-US: English (United States) - default
  * - en-GB: English (United Kingdom)
  * - es-ES: Spanish (Spain)
@@ -10,13 +10,18 @@
  * - pt-PT: Portuguese (Portugal)
  * - de-DE: German (Germany)
  * - nl-NL: Dutch (Netherlands)
+ * - aa-ER: Afar (Eritrea)
  *
  * In development, a 'pseudo' locale is available for QA testing.
  * Generate it with: make i18n-pseudo
+ *
+ * This list is the single source of truth for shipped locales. It is enforced
+ * by src/test/i18n.test.ts (every locale here must have every en-US key) and
+ * must stay in sync with the backend's SUPPORTED_LOCALES (app/routers/settings.py).
  */
 
 // Production locales (always available)
-const productionLocales = ['en-US', 'en-GB', 'es-ES', 'fr-FR', 'it-IT', 'pt-PT', 'de-DE', 'nl-NL'] as const;
+export const productionLocales = ['en-US', 'en-GB', 'es-ES', 'fr-FR', 'it-IT', 'pt-PT', 'de-DE', 'nl-NL', 'aa-ER'] as const;
 
 // Dev-only locale for QA testing (not shipped to production)
 const devLocales = ['pseudo'] as const;
@@ -41,6 +46,7 @@ export const languageNames: Record<Locale, string> = {
   'de-DE': '🇩🇪 Deutsch',
   'nl-NL': '🇳🇱 Nederlands',
   'pt-PT': '🇵🇹 Português',
+  'aa-ER': '🇪🇷 Qafar af',
   'pseudo': '🔤 [Ƥşḗḗŭŭḓǿǿ]',
 };
 

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -22,6 +22,7 @@ const LOCALE_CURRENCIES: Record<string, string> = {
   'es-ES': 'EUR',
   'pt-PT': 'EUR',
   'nl-NL': 'EUR',
+  'aa-ER': 'ERN', // Eritrean nakfa
   'pseudo': 'USD', // Use USD for pseudo-locale testing
 }
 
@@ -39,6 +40,7 @@ const LOCALE_LARGE_THRESHOLDS: Record<string, number> = {
   'es-ES': 85,   // €85 EUR
   'pt-PT': 85,   // €85 EUR
   'nl-NL': 85,   // €85 EUR
+  'aa-ER': 1500, // ~Nfk 1500 (rough purchasing-power equivalent)
   'pseudo': 100, // Use same as en-US for testing
 }
 

--- a/frontend/src/test/i18n.test.ts
+++ b/frontend/src/test/i18n.test.ts
@@ -4,10 +4,11 @@
  * Ensures all translation files have the same keys as en-US.json (the source of truth)
  */
 import { describe, it, expect } from 'vitest'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import enUS from '../messages/en-US.json'
 import universal from '../messages/universal.json'
+import { productionLocales, defaultLocale } from '../i18n'
 
 /**
  * Recursively extract all keys from a nested object
@@ -87,6 +88,68 @@ function findUnchangedStrings(
   return unchanged
 }
 
+/**
+ * Extract ICU/next-intl argument names from a message string.
+ * Matches the identifier immediately after an opening brace: "{count}" -> count,
+ * "{count, plural, one {# item} other {# items}}" -> count (and any nested args).
+ * Used to verify a translation keeps the same placeholders as the source — a
+ * dropped or renamed {var} throws at render time in next-intl.
+ */
+function getPlaceholders(str: string): Set<string> {
+  const names = new Set<string>()
+  const re = /\{\s*([a-zA-Z0-9_]+)/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(str)) !== null) {
+    names.add(m[1])
+  }
+  return names
+}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false
+  for (const x of a) if (!b.has(x)) return false
+  return true
+}
+
+/**
+ * Walk source + target in parallel, returning the keys whose placeholder sets
+ * differ. Keys missing from target are skipped (the completeness test reports those).
+ */
+function findPlaceholderMismatches(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  prefix = ''
+): string[] {
+  const mismatches: string[] = []
+
+  for (const [key, sourceValue] of Object.entries(source)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key
+    const targetValue = target?.[key]
+    if (targetValue === undefined) continue
+
+    if (Array.isArray(sourceValue) && Array.isArray(targetValue)) {
+      sourceValue.forEach((item, index) => {
+        if (typeof item === 'string' && typeof targetValue[index] === 'string' &&
+            !setsEqual(getPlaceholders(item), getPlaceholders(targetValue[index]))) {
+          mismatches.push(`${fullKey}.${index}`)
+        }
+      })
+    } else if (sourceValue && typeof sourceValue === 'object' &&
+               targetValue && typeof targetValue === 'object') {
+      mismatches.push(...findPlaceholderMismatches(
+        sourceValue as Record<string, unknown>,
+        targetValue as Record<string, unknown>,
+        fullKey
+      ))
+    } else if (typeof sourceValue === 'string' && typeof targetValue === 'string' &&
+               !setsEqual(getPlaceholders(sourceValue), getPlaceholders(targetValue))) {
+      mismatches.push(fullKey)
+    }
+  }
+
+  return mismatches
+}
+
 // Universal strings from universal.json - intentionally same across all languages
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const UNIVERSAL_STRINGS = new Set(getAllKeys(universal as Record<string, unknown>))
@@ -101,9 +164,42 @@ describe('i18n translations', () => {
     })
   })
 
-  // Note: We don't test that all locales have all keys from en-US.json
-  // Crowdin manages translations and syncs new keys automatically.
-  // The pseudo locale tests below verify the source strings are valid.
+  // Every shipped (production) locale must contain every key in en-US.json and
+  // preserve its ICU placeholders. This is the gate that would have caught the
+  // ~68-key drift that left every locale silently behind the source for months,
+  // and it catches translations that drop/rename a {placeholder} (a render-time crash).
+  describe('shipped locales match en-US.json', () => {
+    const shippedLocales = productionLocales.filter((locale) => locale !== defaultLocale)
+
+    for (const locale of shippedLocales) {
+      const messages = JSON.parse(
+        readFileSync(join(__dirname, `../messages/${locale}.json`), 'utf-8')
+      ) as Record<string, unknown>
+      const localeKeys = new Set(getAllKeys(messages))
+
+      it(`${locale}: has every key from en-US.json`, () => {
+        const missing = [...sourceKeys].filter((key) => !localeKeys.has(key))
+        if (missing.length > 0) {
+          throw new Error(
+            `${locale}.json is missing ${missing.length} key(s) from en-US.json ` +
+            `(run the Crowdin Sync workflow to pull translations):\n` +
+            missing.map((k) => `  - ${k}`).join('\n')
+          )
+        }
+      })
+
+      it(`${locale}: preserves en-US placeholders`, () => {
+        const mismatches = findPlaceholderMismatches(enUS, messages)
+        if (mismatches.length > 0) {
+          throw new Error(
+            `${locale}.json has ${mismatches.length} string(s) whose {placeholders} ` +
+            `differ from en-US.json (fix the translation in Crowdin):\n` +
+            mismatches.map((k) => `  ! ${k}`).join('\n')
+          )
+        }
+      })
+    }
+  })
 
   // pseudo.json is gitignored and only available in dev when generated
   // Skip these tests if the file doesn't exist (e.g., in CI)

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -485,7 +485,7 @@ export const handlers = [
     return HttpResponse.json({
       language: 'browser',
       effective_locale: effectiveLocale,
-      supported_locales: ['en-US', 'en-GB', 'es-ES', 'fr-FR', 'it-IT', 'pt-PT', 'de-DE', 'nl-NL', 'pseudo'],
+      supported_locales: ['en-US', 'en-GB', 'es-ES', 'fr-FR', 'it-IT', 'pt-PT', 'de-DE', 'nl-NL', 'aa-ER', 'pseudo'],
     })
   }),
 


### PR DESCRIPTION
Makes the i18n setup robust so it can't silently rot again (the prior integration drifted ~68 keys behind for 5 months with nobody noticing). Tier 1 + 2 of the robustness plan.

## Safety gates

| Gate | Where | Catches |
|---|---|---|
| **Locale completeness** | `frontend/src/test/i18n.test.ts` | A shipped locale missing any `en-US.json` key. *This is the check that was missing* — the old test only validated `pseudo`. |
| **Placeholder integrity** | `frontend/src/test/i18n.test.ts` | A translation that drops/renames an ICU `{placeholder}` (a next-intl render crash). |
| **Source guard** | `.github/workflows/i18n-guard.yaml` | A PR that hand-edits a Crowdin-managed locale file. `en-US`/`pseudo`/`universal`/`schema` and the `l10n/crowdin` PR are exempt. |
| **Notify on failure** | `.github/workflows/crowdin.yaml` | A scheduled/push sync failure — opens/updates a `crowdin-sync-failure` issue instead of failing into the void. |

## Ship aa-ER (Afar) as a real locale

It was being downloaded by Crowdin but not wired into the app. Now shipped end-to-end — **no DB migration** since the `language` column is `String`, not a SQL enum:
- Frontend: `productionLocales` + `languageNames` + date-fns/currency/threshold maps
- Backend: `LanguagePreference` enum + `SUPPORTED_LOCALES` (+ test)

`productionLocales` (`frontend/src/i18n.ts`) is now the single source of truth; docs note it must match the backend list/enum.

## Verification
- 573 frontend unit tests pass; `tsc --noEmit` + eslint clean
- 1158 backend tests pass; ruff clean
- Both new/edited workflows validated; guard grep logic unit-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)