### PR TITLE
ci(i18n): auto-merge Crowdin translation PR when CI passes (Tier 4)

### DIFF
--- a/.github/workflows/crowdin-automerge.yaml
+++ b/.github/workflows/crowdin-automerge.yaml
@@ -1,0 +1,54 @@
+name: Crowdin Auto-merge
+
+# Tier 4: when CI passes on the Crowdin translation PR (branch l10n/crowdin),
+# merge it automatically — no manual step.
+#
+# Why this needs an admin PAT and can't use the built-in GITHUB_TOKEN:
+#   - The PR is authored by github-actions[bot], which cannot approve its own PR.
+#   - main requires 1 review + an "E2E Tests" check that is SKIPPED on
+#     translation-only PRs, so native auto-merge would stall.
+# So we wait for the CI workflow to conclude success, then admin-bypass merge
+# (enforce_admins is off) using GH_AUTOMERGE_TOKEN — a PAT belonging to a repo
+# admin. Setup instructions: docs/i18n-workflow.md ("Auto-merge").
+
+"on":
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crowdin-automerge
+  cancel-in-progress: false
+
+jobs:
+  automerge:
+    name: Admin-merge the green translation PR
+    runs-on: ubuntu-latest
+    # Only the Crowdin PR, only from this repo (not a fork), only when CI passed.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_branch == 'l10n/crowdin' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Merge if a PAT is configured
+        env:
+          GH_TOKEN: ${{ secrets.GH_AUTOMERGE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::GH_AUTOMERGE_TOKEN is not set — skipping auto-merge. Add the PAT to enable it (see docs/i18n-workflow.md)."
+            exit 0
+          fi
+          pr=$(gh pr list --repo "$REPO" --head l10n/crowdin --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$pr" ]; then
+            echo "No open l10n/crowdin PR to merge."
+            exit 0
+          fi
+          echo "CI passed — admin-merging PR #$pr"
+          gh pr merge "$pr" --repo "$REPO" --squash --admin --delete-branch

--- a/docs/i18n-workflow.md
+++ b/docs/i18n-workflow.md
@@ -223,6 +223,17 @@ These checks make i18n problems loud instead of silent (the prior setup drifted 
 
 The shipped locale set is defined once in `frontend/src/i18n.ts` (`productionLocales`) and must match the backend's `SUPPORTED_LOCALES` (`backend/app/routers/settings.py`) and `LanguagePreference` enum (`backend/app/orm.py`).
 
+### Auto-merge
+
+`.github/workflows/crowdin-automerge.yaml` merges the translation PR automatically once CI passes, so translations land hands-free. It needs a personal access token because the PR is authored by `github-actions[bot]` (which can't approve its own PR) and `main` requires a review plus an `E2E Tests` check that translation PRs skip.
+
+One-time setup:
+1. Create a **fine-grained PAT** scoped to this repository with **Contents: Read & write** and **Pull requests: Read & write** (the token's owner must be a repo admin, since the merge bypasses branch protection). If the admin merge is rejected, also grant **Administration: Read & write**.
+2. Add it as the repo secret **`GH_AUTOMERGE_TOKEN`** (Settings → Secrets and variables → Actions).
+3. Note the expiry — when the PAT expires, auto-merge silently no-ops (the workflow logs a warning) and you fall back to merging the PR by hand.
+
+Without the secret the workflow is a safe no-op; you just merge the Crowdin PR manually.
+
 ## Configuration
 
 ### Crowdin Config (`crowdin.yaml`)


### PR DESCRIPTION
Final robustness tier: translations land hands-free.

`.github/workflows/crowdin-automerge.yaml` triggers on the **CI** workflow completing for the `l10n/crowdin` PR and, if CI concluded success, admin-merges it (squash + delete branch).

**Why a PAT is required** (confirmed against this repo's protection):
- The Crowdin PR is authored by `github-actions[bot]` → `GITHUB_TOKEN` can't approve it (self-approval rule).
- `main` requires 1 review + an `E2E Tests` check that is **skipped** on translation PRs → native auto-merge stalls.
- `enforce_admins: false`, so an **admin** can bypass — but `GITHUB_TOKEN` isn't an admin. Hence `GH_AUTOMERGE_TOKEN` (a repo-admin PAT).

**Safety:** gated on `workflow_run.conclusion == 'success'`, the `l10n/crowdin` branch, and `head_repository == this repo` (forks can't trigger it). Absent the secret it's a logged no-op — you just merge manually.

### One-time setup (you)
1. Create a fine-grained PAT for this repo: **Contents: RW** + **Pull requests: RW** (owner must be a repo admin; add **Administration: RW** if admin-merge is refused).
2. Add it as secret **`GH_AUTOMERGE_TOKEN`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)