### PR TITLE
fix(ci): repin codeql-action to a real commit SHA (fixes Scorecard + 14 stale alerts)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -225,7 +225,7 @@ jobs:
         severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
         docker-host: 'unix:///var/run/docker.sock'
     - name: Upload Trivy SARIF to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
       if: always() && hashFiles('trivy-results.sarif') != ''
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/dast.yaml
+++ b/.github/workflows/dast.yaml
@@ -127,7 +127,7 @@ jobs:
           }' report_json.json > zap-sarif.json
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         if: always() && hashFiles('zap-sarif.json') != ''
         with:
           sarif_file: zap-sarif.json

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -32,8 +32,12 @@ jobs:
           results_format: sarif
           publish_results: true
 
+      # Always upload, even if the publish_results step above had a transient
+      # failure — otherwise the GitHub Security alerts never refresh and stale
+      # findings linger (which is exactly what happened with the imposter pin).
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        if: always()
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         if: always()
         with:
           sarif_file: semgrep.sarif
@@ -143,7 +143,7 @@ jobs:
             --enableExperimental
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         if: always() && hashFiles('reports/dependency-check-report.sarif') != ''
         with:
           sarif_file: reports/dependency-check-report.sarif


### PR DESCRIPTION
## What was wrong

The **OpenSSF Scorecard** workflow has been failing (masked by `continue-on-error`). Its `publish_results` step is rejected by scorecard.dev:

```
imposter commit: dc73d59c…e6d8a1719 does not belong to github/codeql-action/upload-sarif
```

**Root cause:** the "pin all actions to SHA" change (#313) pinned `github/codeql-action/upload-sarif` to the **`v4` annotated-tag *object* SHA** (`dc73d59…`) instead of the **commit** it points to (`7211b7c8…`). `dc73d59` isn't a real commit (`GET /commits/dc73d59` → 404), so scorecard.dev's imposter check rejects it and the step fails → the `Upload SARIF` step is skipped → the GitHub Security alerts never refresh.

That's also why the **14 "Pinned-Dependencies" alerts** won't clear: they're stale (from an old scan when `jdx/mise-action@v2` was unpinned). Current main is fully pinned — Scorecard now scores **Pinned-Dependencies 10/10** ("all dependencies are pinned"). They just need a fresh SARIF upload to auto-close.

## Fix
- Repin all **5** occurrences (ci, security ×2, dast, scorecard) → `7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4` (verified real commit).
- `scorecard.yaml`: upload SARIF with `if: always()` so the Security tab refreshes even if `publish_results` flakes.
- Swept **every** pinned action across all workflows — all other SHAs resolve to real commits.

## After merge
Scorecard runs on push to main → uploads fresh SARIF → the 14 Pinned-Dependencies alerts auto-close.

The **Code-Review** (High, #105) alert is separate — it reflects PRs merged without an approving review (solo repo); not fixable in code. Discussed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)