### PR TITLE
fix(ci): least-privilege token permissions in crowdin.yaml

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -30,9 +30,9 @@ name: Crowdin Sync
         type: boolean
         default: true
 
+# Least privilege: read by default; write is scoped to the jobs that need it.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # Never let two syncs race each other against the same Crowdin project.
 concurrency:
@@ -43,6 +43,9 @@ jobs:
   crowdin:
     name: Crowdin Sync
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push the l10n/crowdin branch
+      pull-requests: write    # open the translation PR
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 


### PR DESCRIPTION
Resolves Scorecard Token-Permissions alert #221: top-level `contents: write` in crowdin.yaml.

- Workflow default → `contents: read`
- `crowdin` job → job-level `contents: write` (push l10n branch) + `pull-requests: write` (open PR)
- `notify-failure` job keeps job-level `issues: write`

The other three Token-Permissions findings (release.yaml, dependabot-auto-merge.yaml, nightly.yaml) are job-scoped writes that are *required* (create releases / enable auto-merge / upload SARIF) with top-level already `read` — handled separately as accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)