### PR TITLE
fix(just): drop redundant uv venv from install-backend (fixes apparent hang)

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,7 +37,9 @@ install-backend:
     source scripts/gum-helpers.sh
     style 12 "Installing backend dependencies..."
     cd backend
-    spin "Creating virtual environment..." uv venv
+    # `uv sync` creates the .venv itself. A separate `uv venv` step errors on
+    # re-runs once .venv exists (newer uv refuses without --clear), and under the
+    # gum spinner that failure is hidden — which looks like a hang.
     spin "Syncing backend packages..." uv sync --all-extras
     style 2 "Backend dependencies installed."
 


### PR DESCRIPTION
## Symptom
`just install` looked like it was hanging.

## Root cause
`install-backend` ran `uv venv` before `uv sync`. Newer `uv` **errors** when `.venv` already exists:
```
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at: .venv
```
The recipe wraps the step in `gum spin`, which **hides the failing command's output** — so instead of an error you just see a spinner that appears stuck.

## Fix
`uv sync` creates the `.venv` on its own (verified), so the `uv venv` step was redundant. Removed it → `just install` is now idempotent across re-runs (~1s when cached).

## Note (separate, minor)
npm warns `EBADENGINE` for `pseudo-localization@3.1.2` (wants node ≥23; `.mise.toml` pins node 22). Advisory only — install and pseudo-locale generation still work on node 22 — but worth a follow-up to bump node or pin the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)