### PR TITLE
fix(i18n): pin pseudo-localization to 2.x for node 22 (clears EBADENGINE)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
       # Tracking: https://github.com/jsx-eslint/eslint-plugin-react/issues/3977
       - dependency-name: "eslint"
         versions: [">=10"]
+      # pseudo-localization 3.x requires node >=23; this project pins node 22.
+      # Stay on 2.x until the project moves to node >=23. (Dev-only QA tool;
+      # the script uses its `localize` export.)
+      - dependency-name: "pseudo-localization"
+        versions: [">=3"]
 
   # Backend (pip/uv)
   - package-ecosystem: "pip"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,7 +42,7 @@
         "jsdom": "^29.1.1",
         "msw": "^2.12.4",
         "postcss": "^8.5.10",
-        "pseudo-localization": "^3.1.1",
+        "pseudo-localization": "^2.4.0",
         "tailwindcss": "^4.1.18",
         "typescript": "^6.0.3",
         "vitest": "^4.0.14"
@@ -7420,6 +7420,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -7714,6 +7724,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/get-stream": {
@@ -10806,16 +10826,33 @@
       }
     },
     "node_modules/pseudo-localization": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pseudo-localization/-/pseudo-localization-3.1.2.tgz",
-      "integrity": "sha512-It9FoSMi9rMbv4z612BCPCcNMQDVeM0kXmy/f3hoxXLzmXp/KDVp7zwDSqSVzrjBcciElY+BRA6p35LZzXYIuQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pseudo-localization/-/pseudo-localization-2.4.0.tgz",
+      "integrity": "sha512-ISYMOKY8+f+PmiXMFw2y6KLY74LBrv/8ml/VjjoVEV2k+MS+OJZz7ydciK5ntJwxPrKQPTU1+oXq9Mx2b0zEzg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "flat": "^5.0.2",
+        "get-stdin": "^7.0.0",
+        "typescript": "^4.7.4",
+        "yargs": "^17.2.1"
+      },
       "bin": {
-        "pseudo-localization": "dist/bin/pseudo-localize.js"
+        "pseudo-localization": "bin/pseudo-localize"
+      }
+    },
+    "node_modules/pseudo-localization/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=23"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/punycode": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "jsdom": "^29.1.1",
     "msw": "^2.12.4",
     "postcss": "^8.5.10",
-    "pseudo-localization": "^3.1.1",
+    "pseudo-localization": "^2.4.0",
     "tailwindcss": "^4.1.18",
     "typescript": "^6.0.3",
     "vitest": "^4.0.14"

--- a/frontend/scripts/generate-pseudo-locale.mjs
+++ b/frontend/scripts/generate-pseudo-locale.mjs
@@ -13,7 +13,9 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { pseudoLocalizeString as localize } from 'pseudo-localization';
+// pseudo-localization 2.x exports `localize` (3.x renamed it to
+// pseudoLocalizeString and dropped node 22 support — we stay on 2.x for node 22).
+import { localize } from 'pseudo-localization';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);


### PR DESCRIPTION
## Symptom
`npm install` warned:
```
npm warn EBADENGINE pseudo-localization@3.1.2 required: { node: '>=23' }, current: v22.x
```

## Fix
`pseudo-localization` is a dev-only QA tool (pseudo-locale generation). Its entire 3.x line requires node ≥23, but the project pins node 22.

- Pin to `^2.4.0` (no node-engine restriction).
- The 2.x export is `localize` (3.x renamed it to `pseudoLocalizeString`), so `generate-pseudo-locale.mjs` imports `localize`. **Output verified identical** (e.g. `Save → Şȧȧṽḗḗ`).
- Dependabot now ignores `pseudo-localization >=3` until the project moves to node ≥23 (otherwise it'd re-bump and re-break).

## Verified
- Pseudo-locale regenerates correctly
- All 21 i18n tests pass
- No EBADENGINE on install

🤖 Generated with [Claude Code](https://claude.com/claude-code)