### PR TITLE
fix(docker): align frontend-builder to node 22 (match dev/CI)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # All-in-One Dockerfile for Maxwell's Wallet
 # Runs both FastAPI backend and Next.js frontend in a single container
 
-FROM node:24-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf AS frontend-builder
+FROM node:22-slim@sha256:7af03b14a13c8cdd38e45058fd957bf00a72bbe17feac43b1c15a689c029c732 AS frontend-builder
 
 # Build args
 ARG ENABLE_PSEUDO=false


### PR DESCRIPTION
## What
The Dockerfile's `frontend-builder` stage ran `node:24-slim`, while the rest of the project pins **node 22** (mise, `.nvmrc`, CI) — and we just pinned `pseudo-localization` to 2.x specifically for node 22. Building the frontend on a different node major than dev/CI invites subtle drift.

## Change
`FROM node:24-slim@sha256:242549c…` → `node:22-slim@sha256:7af03b14…` (digest-pinned, so the container image stays pinned for Scorecard).

The frontend build already runs on node 22 in the CI Frontend job, so this just makes the Docker build environment consistent. The Docker Build & Smoke Test will validate.

> The runtime stage's apt `nodejs` is a separate, pre-existing concern (debian-packaged node for `server.js`) — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)