### PR TITLE
ci(deps): auto-approve Dependabot patch/minor PRs (closes #312)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -21,6 +21,13 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Approve patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+
       - name: Enable auto-merge for patch and minor updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

The `dependabot-auto-merge.yaml` workflow already enables auto-merge (`gh pr merge --auto --squash`) for patch and minor Dependabot updates. However, `main` requires 1 approving review under branch protection, and there was no approval step, so auto-merge could never complete and these PRs stalled.

## Change

Adds an **Approve patch and minor updates** step immediately before the enable-auto-merge step, gated to the same patch/minor `update-type` conditions. It runs `gh pr review --approve` using the built-in `GITHUB_TOKEN`.

This works because the PR author is `dependabot[bot]` while the approver is `github-actions[bot]` (a different identity), and the repo setting *Allow GitHub Actions to create and approve pull requests* is now enabled. No PAT is required.

The major-version comment step is unchanged.

Closes #312