### PR TITLE
fix(i18n): route Tools/Organize page titles through next-intl (closes #232)

### DIFF
--- a/frontend/src/components/ProtectedProviders.tsx
+++ b/frontend/src/components/ProtectedProviders.tsx
@@ -28,14 +28,21 @@ function deepMerge(base: Record<string, unknown>, override: Record<string, unkno
 
 // Dynamic message loader - merges locale messages with universal strings
 async function loadMessages(locale: string): Promise<Record<string, unknown>> {
+  // The pseudo locale is a QA/test locale where EVERY string must be
+  // transformed (accented). Universal strings (e.g. "Tools") are intentionally
+  // identical English across real languages, but merging them over pseudo would
+  // leave those keys as plain English and defeat the i18n-coverage tests, so we
+  // skip the universal merge for pseudo.
+  const mergeUniversal = (msgs: Record<string, unknown>) =>
+    locale === 'pseudo' ? msgs : deepMerge(msgs, universal)
   try {
     const localeMessages = (await import(`@/messages/${locale}.json`)).default
-    return deepMerge(localeMessages, universal)
+    return mergeUniversal(localeMessages)
   } catch {
     // Fallback to default locale if message file not found
     console.warn(`Messages for locale "${locale}" not found, falling back to ${defaultLocale}`)
     const fallbackMessages = (await import(`@/messages/${defaultLocale}.json`)).default
-    return deepMerge(fallbackMessages, universal)
+    return mergeUniversal(fallbackMessages)
   }
 }
 
@@ -86,6 +93,14 @@ export function ProtectedProviders({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     async function initLocale() {
+      // Allow an explicit locale override via localStorage (used by QA / E2E
+      // pseudo-locale tests). This takes precedence over the API-resolved
+      // locale and is never set in normal production usage.
+      const override = typeof window !== 'undefined' ? window.localStorage.getItem('locale') : null
+      if (override && isValidLocale(override)) {
+        setLocale(override)
+      }
+
       try {
         // Fetch effective locale from settings API
         const res = await fetch('/api/v1/settings')
@@ -93,8 +108,8 @@ export function ProtectedProviders({ children }: { children: ReactNode }) {
           const data = await res.json()
           const effectiveLocale = data.effective_locale || defaultLocale
 
-          // Validate and set locale
-          if (isValidLocale(effectiveLocale)) {
+          // Validate and set locale (skip if a localStorage override is active)
+          if (!(override && isValidLocale(override)) && isValidLocale(effectiveLocale)) {
             setLocale(effectiveLocale)
           }
 

--- a/frontend/src/components/Providers.tsx
+++ b/frontend/src/components/Providers.tsx
@@ -25,14 +25,21 @@ function deepMerge(base: Record<string, unknown>, override: Record<string, unkno
 
 // Dynamic message loader - merges locale messages with universal strings
 async function loadMessages(locale: string): Promise<Record<string, unknown>> {
+  // The pseudo locale is a QA/test locale where EVERY string must be
+  // transformed (accented). Universal strings (e.g. "Tools") are intentionally
+  // identical English across real languages, but merging them over pseudo would
+  // leave those keys as plain English and defeat the i18n-coverage tests, so we
+  // skip the universal merge for pseudo.
+  const mergeUniversal = (msgs: Record<string, unknown>) =>
+    locale === 'pseudo' ? msgs : deepMerge(msgs, universal)
   try {
     const localeMessages = (await import(`@/messages/${locale}.json`)).default
-    return deepMerge(localeMessages, universal)
+    return mergeUniversal(localeMessages)
   } catch {
     // Fallback to default locale if message file not found
     console.warn(`Messages for locale "${locale}" not found, falling back to ${defaultLocale}`)
     const fallbackMessages = (await import(`@/messages/${defaultLocale}.json`)).default
-    return deepMerge(fallbackMessages, universal)
+    return mergeUniversal(fallbackMessages)
   }
 }
 
@@ -44,6 +51,14 @@ export function Providers({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     async function initLocale() {
+      // Allow an explicit locale override via localStorage (used by QA / E2E
+      // pseudo-locale tests). This takes precedence over the API-resolved
+      // locale and is never set in normal production usage.
+      const override = typeof window !== 'undefined' ? window.localStorage.getItem('locale') : null
+      if (override && isValidLocale(override)) {
+        setLocale(override)
+      }
+
       try {
         // Fetch effective locale from settings API
         const res = await fetch('/api/v1/settings')
@@ -51,8 +66,8 @@ export function Providers({ children }: { children: ReactNode }) {
           const data = await res.json()
           const effectiveLocale = data.effective_locale || defaultLocale
 
-          // Validate and set locale
-          if (isValidLocale(effectiveLocale)) {
+          // Validate and set locale (skip if a localStorage override is active)
+          if (!(override && isValidLocale(override)) && isValidLocale(effectiveLocale)) {
             setLocale(effectiveLocale)
           }
 


### PR DESCRIPTION
## Problem

The nightly i18n-coverage E2E tests (`frontend/e2e/i18n-coverage.spec.ts`) assert that every page title renders pseudo-localized (accented) under the `pseudo` locale. The suite was failing with errors like:

```
Error: Tools page title should be pseudo-localized. Got: "Tools"
Error: Organize page title should be pseudo-localized. Got: "Organize"
```

(and in fact every page title — Dashboard, Transactions, Budgets, Import, Admin — was rendering as plain English too).

## Root cause

The Tools and Organize pages already call `useTranslations(...).t('title')` correctly — they were never hardcoded. The real defects were upstream of the components:

1. **Locale never switched to pseudo.** `Providers` / `ProtectedProviders` resolve the active locale solely from `/api/v1/settings` `effective_locale`. The E2E tests set the locale via `localStorage.setItem('locale', 'pseudo')`, but the providers never read localStorage, so the app stayed on `en-US` and nothing was pseudo-localized.

2. **universal.json overrode pseudo strings back to English.** `universal.json` (strings intentionally identical across real languages, e.g. `tools.title` = "Tools", `nav.tools` = "Tools") is deep-merged *over* the locale messages. For the pseudo locale this overwrote the already-transformed keys back to plain English, so "Tools" could never be pseudo-localized even once the locale was correctly applied. (`organize.title` is not in universal.json, which is why Organize hinged purely on issue #1.)

## Fix

- Honor a `localStorage('locale')` override ahead of the API-resolved locale in both providers. This is used only by QA / E2E pseudo-locale testing and is never set in normal production usage.
- Skip the universal-strings merge for the `pseudo` locale so every string is fully transformed. Real-locale behavior is unchanged (universal still merges for en-US and all shipped locales).

No message files were edited (`en-US.json` and `universal.json` are untouched), so the i18n completeness gate (`src/test/i18n.test.ts`) is unaffected.

## Verification

- `i18n-coverage.spec.ts`: 12/12 pass on chromium (was failing all page-title + nav tests).
- `i18n.spec.ts`: passes, no regression.
- `npm run test:run`: all 573 frontend unit tests pass, including `src/test/i18n.test.ts`.
- `tsc --noEmit` and `eslint` clean.

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)