### PR TITLE
fix(dashboard): prevent client-side crash under chaos interactions (closes #279)

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -18,10 +18,44 @@ from app.schemas import DashboardLayoutUpdate, DashboardWidgetCreate, DashboardW
 from app.errors import ErrorCode, not_found, bad_request
 
 
+async def _resolve_default_dashboard(session: AsyncSession) -> Dashboard | None:
+    """Return the canonical default dashboard, healing duplicate defaults.
+
+    Uses ``scalars().all()`` (never ``scalar_one_or_none``) so a state with
+    more than one ``is_default=True`` row does not raise MultipleResultsFound.
+    When duplicates are found, the lowest position/id wins and the rest have
+    their default flag cleared so subsequent reads are unambiguous.
+    """
+    result = await session.execute(
+        select(Dashboard)
+        .where(Dashboard.is_default.is_(True))
+        .order_by(Dashboard.position, Dashboard.id)
+    )
+    defaults = list(result.scalars().all())
+
+    if not defaults:
+        return None
+
+    canonical = defaults[0]
+    if len(defaults) > 1:
+        # Self-heal: keep only the canonical dashboard as default.
+        for extra in defaults[1:]:
+            extra.is_default = False
+        await session.commit()
+        await session.refresh(canonical)
+
+    return canonical
+
+
 async def get_default_dashboard_id(session: AsyncSession) -> int:
-    """Get the default dashboard ID, creating one with widgets if needed."""
-    result = await session.execute(select(Dashboard).where(Dashboard.is_default.is_(True)))
-    dashboard = result.scalar_one_or_none()
+    """Get the default dashboard ID, creating one with widgets if needed.
+
+    Tolerates a corrupted state where multiple dashboards are flagged as
+    default (which concurrent/interleaved writes can produce). In that case
+    the lowest-position/id dashboard is chosen deterministically and the
+    extra default flags are cleared so the state self-heals.
+    """
+    dashboard = await _resolve_default_dashboard(session)
 
     if not dashboard:
         # Create default dashboard

--- a/backend/app/routers/dashboards.py
+++ b/backend/app/routers/dashboards.py
@@ -146,9 +146,27 @@ DEFAULT_WIDGETS = [
 
 
 async def get_or_create_default_dashboard(session: AsyncSession) -> Dashboard:
-    """Get the default dashboard, creating one if none exists."""
-    result = await session.execute(select(Dashboard).where(Dashboard.is_default.is_(True)))
-    dashboard = result.scalar_one_or_none()
+    """Get the default dashboard, creating one if none exists.
+
+    Tolerates a corrupted state with multiple ``is_default=True`` rows
+    (which concurrent/interleaved writes can produce) instead of raising
+    MultipleResultsFound. The lowest-position/id dashboard wins and any
+    extra default flags are cleared so the state self-heals.
+    """
+    result = await session.execute(
+        select(Dashboard)
+        .where(Dashboard.is_default.is_(True))
+        .order_by(Dashboard.position, Dashboard.id)
+    )
+    defaults = list(result.scalars().all())
+    dashboard = defaults[0] if defaults else None
+
+    if dashboard is not None and len(defaults) > 1:
+        # Self-heal: keep only the canonical dashboard as default.
+        for extra in defaults[1:]:
+            extra.is_default = False
+        await session.commit()
+        await session.refresh(dashboard)
 
     if not dashboard:
         # Create default dashboard with MTD date range

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -243,3 +243,56 @@ class TestDashboardWidgets:
         assert len(widgets2) == initial_count - 1
         widget_types = [w["widget_type"] for w in widgets2]
         assert "velocity" not in widget_types
+
+
+class TestDuplicateDefaultDashboards:
+    """Regression tests for issue #279.
+
+    Concurrent/interleaved dashboard writes (e.g. chaos testing) could leave
+    multiple dashboards flagged ``is_default=True``. The widgets endpoint then
+    raised ``MultipleResultsFound`` (500), which crashed the frontend dashboard
+    with a client-side exception. The default-dashboard resolution must tolerate
+    and self-heal that state instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_widgets_with_multiple_defaults(self, client: AsyncClient, async_session):
+        """Two default dashboards must not 500 the widgets endpoint."""
+        from app.orm import Dashboard
+
+        async_session.add_all(
+            [
+                Dashboard(name="A", view_mode="month", is_default=True, position=0),
+                Dashboard(name="B", view_mode="month", is_default=True, position=1),
+            ]
+        )
+        await async_session.commit()
+
+        response = await client.get("/api/v1/dashboard/widgets")
+        assert response.status_code == 200, response.text
+
+    @pytest.mark.asyncio
+    async def test_multiple_defaults_self_heal(self, client: AsyncClient, async_session):
+        """After resolving, exactly one dashboard should remain default."""
+        from sqlalchemy import select
+        from app.orm import Dashboard
+
+        async_session.add_all(
+            [
+                Dashboard(name="A", view_mode="month", is_default=True, position=0),
+                Dashboard(name="B", view_mode="month", is_default=True, position=1),
+                Dashboard(name="C", view_mode="month", is_default=True, position=2),
+            ]
+        )
+        await async_session.commit()
+
+        # Trigger resolution via the widgets endpoint.
+        response = await client.get("/api/v1/dashboard/widgets")
+        assert response.status_code == 200, response.text
+
+        async_session.expire_all()
+        result = await async_session.execute(select(Dashboard).where(Dashboard.is_default.is_(True)))
+        defaults = list(result.scalars().all())
+        assert len(defaults) == 1
+        # Lowest position/id wins.
+        assert defaults[0].name == "A"

--- a/backend/tests/test_dashboards.py
+++ b/backend/tests/test_dashboards.py
@@ -461,3 +461,48 @@ class TestDashboardWidgets:
         widgets2 = response2.json()
 
         assert len(widgets1) == len(widgets2)
+
+
+class TestDuplicateDefaultDashboards:
+    """Regression tests for issue #279 on the /dashboards endpoints.
+
+    ``get_or_create_default_dashboard`` must not raise MultipleResultsFound
+    when more than one dashboard is flagged as default; it should resolve
+    deterministically and self-heal.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_default_with_multiple_defaults(self, client: AsyncClient, async_session):
+        from app.orm import Dashboard
+
+        async_session.add_all(
+            [
+                Dashboard(name="A", view_mode="month", is_default=True, position=0),
+                Dashboard(name="B", view_mode="month", is_default=True, position=1),
+            ]
+        )
+        await async_session.commit()
+
+        response = await client.get("/api/v1/dashboards/default")
+        assert response.status_code == 200, response.text
+        assert response.json()["name"] == "A"
+
+    @pytest.mark.asyncio
+    async def test_list_dashboards_with_multiple_defaults(self, client: AsyncClient, async_session):
+        from sqlalchemy import select
+        from app.orm import Dashboard
+
+        async_session.add_all(
+            [
+                Dashboard(name="A", view_mode="month", is_default=True, position=0),
+                Dashboard(name="B", view_mode="month", is_default=True, position=1),
+            ]
+        )
+        await async_session.commit()
+
+        # List itself doesn't resolve defaults, but the default endpoint heals them.
+        await client.get("/api/v1/dashboards/default")
+
+        async_session.expire_all()
+        result = await async_session.execute(select(Dashboard).where(Dashboard.is_default.is_(True)))
+        assert len(list(result.scalars().all())) == 1

--- a/frontend/e2e/chaos/chaos-dashboard.spec.ts
+++ b/frontend/e2e/chaos/chaos-dashboard.spec.ts
@@ -85,6 +85,22 @@ test.describe('Dashboard Tab Switching Chaos @chaos', () => {
     // 5 rounds: switch tab, do 8 actions
     for (let round = 0; round < 5; round++) {
       const tabIndex = rng.int(0, tabCount - 1);
+
+      // Chaos actions in the previous round may have (a) navigated away from the
+      // dashboard via a nav link, or (b) left a full-screen backdrop overlay open
+      // (e.g. the "customize dashboard" panel) that intercepts pointer events.
+      // Either of these makes the tab click hang until the test times out
+      // (see issue #279). Reset to a known-good state before switching tabs:
+      // dismiss any overlay, return to the dashboard, and wait for the tabs.
+      await page.keyboard.press('Escape');
+      if (!page.url().endsWith('/')) {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+      }
+      await page
+        .locator('[data-testid="dashboard-selector"]')
+        .waitFor({ state: 'visible', timeout: 10000 });
+
       await tabs.nth(tabIndex).click();
       await page.waitForTimeout(50);
 

--- a/frontend/e2e/chaos/chaos-helpers.ts
+++ b/frontend/e2e/chaos/chaos-helpers.ts
@@ -432,6 +432,27 @@ async function executeAction(
           });
           if (isDisabled) continue;
 
+          // Honor caller-provided exclusions (e.g. nav links so a test can stay
+          // on one page). Without this, click-target would freely click any
+          // [data-chaos-target] element, including nav links, navigating away
+          // and breaking page-scoped tests (see issue #279).
+          let excluded = false;
+          for (const excludeSel of excludeSelectors) {
+            try {
+              const matches = await target.evaluate(
+                (el, sel) => el.matches(sel),
+                excludeSel
+              );
+              if (matches) {
+                excluded = true;
+                break;
+              }
+            } catch {
+              // Selector might not be valid for this element
+            }
+          }
+          if (excluded) continue;
+
           eligibleTargets.push(target);
         } catch {
           // Element may have become stale, skip it

--- a/frontend/src/components/DashboardConfig.tsx
+++ b/frontend/src/components/DashboardConfig.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 
@@ -61,6 +61,17 @@ export function DashboardConfig({
   const tDash = useTranslations('dashboard')
   const tWidgets = useTranslations('dashboard.widgets')
   const [isOpen, setIsOpen] = useState(false)
+
+  // Close the panel on Escape so its full-screen backdrop never gets stuck
+  // open and blocking interaction with the rest of the dashboard (issue #279).
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen])
 
   const sortedWidgets = [...widgets].sort((a, b) => a.position - b.position)
 


### PR DESCRIPTION
## Summary

The nightly dashboard chaos suite triggered a client-side crash across all browsers (`expect(result.errors).toEqual([])` failing with 1 error, the page showing "Application error: a client-side exception has occurred", plus a `locator.click: Test timeout of 60000ms exceeded`).

## Root cause

`get_default_dashboard_id` in `backend/app/routers/dashboard.py` (and `get_or_create_default_dashboard` in `dashboards.py`) resolved the default dashboard with `scalar_one_or_none()`. When **more than one** dashboard was flagged `is_default=True`, SQLAlchemy raised `MultipleResultsFound`, returning **HTTP 500** from `/api/v1/dashboard/widgets` and `/api/v1/dashboards/default`. The failed fetch surfaced in the frontend as the client-side exception.

This duplicate-default state is produced **deterministically by the CI setup itself**: `just db::init` creates a `Default` dashboard (id=1, is_default=1), then `just db::seed` adds `Monthly Overview` (id=2) as default without clearing the first — leaving two defaults. That is why the `MultipleResultsFound` 500 appears in the CI log from the very first chaos action. The same state can also arise from concurrent/interleaved dashboard writes during chaos.

**Reproducing seed:** `11111` (the "tab switching with interleaved actions" test), with the Fibonacci ramp tests using seeds `12345`-`12349`. The deterministic backend trigger is simply `just db::init && just db::seed` (two `is_default=1` rows).

## Fix

**Backend (the actual bug):** resolve the default dashboard with an ordered `scalars().all()` that never raises on duplicates, deterministically pick the lowest `position`/`id`, and **self-heal** by clearing the extra `is_default` flags so subsequent reads are unambiguous.

**Chaos-test robustness (the `locator.click` timeout symptom):**
- `DashboardConfig` now closes on **Escape**, so its full-screen `fixed inset-0 z-40` backdrop can no longer get stuck open and intercept pointer events on the dashboard tabs.
- The chaos `click-target` action now honors `excludeSelectors` (previously ignored), so the tab-switching test's nav-link exclusion actually keeps it on the dashboard instead of navigating away to another page and then hanging on a now-missing tab.

Regression tests added for the multiple-default state on both endpoint groups, including the self-heal assertion.

## Verification

- Reproduced `MultipleResultsFound` deterministically with a focused backend test (failed pre-fix, passes post-fix).
- Confirmed against a **live server** seeded into the two-default state: `/api/v1/dashboard/widgets` and `/api/v1/dashboards/default` now return **200** and the DB self-heals from 2 defaults to 1.
- Full dashboard chaos spec passes **7/7 on chromium** (`28.7s`), with the DB observed self-healing to a single default during the run.
- `backend` dashboard suites: **52 passed**. Frontend `tsc --noEmit` clean, ESLint clean, `ruff`/`mypy` clean on changed files.

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)