### PR TITLE
fix(ci): run E2E on code PRs; gate skip on Crowdin branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,13 +16,12 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       backend: ${{ steps.filter.outputs.backend }}
       docker: ${{ steps.filter.outputs.docker }}
-      translations-only: ${{ steps.filter.outputs.translations-only }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
-        filters: "frontend:\n  - 'frontend/**'\nbackend:\n  - 'backend/**'\ndocker:\n  - 'Dockerfile'\n  - 'docker-compose*.yaml'\ntranslations-only:\n  - 'frontend/src/messages/**'\n  - '!frontend/src/**/*.ts'\n  - '!frontend/src/**/*.tsx'\n  - '!backend/**'\n"
+        filters: "frontend:\n  - 'frontend/**'\nbackend:\n  - 'backend/**'\ndocker:\n  - 'Dockerfile'\n  - 'docker-compose*.yaml'\n"
   security:
     name: Security Scans
     uses: ./.github/workflows/security.yaml
@@ -90,7 +89,7 @@ jobs:
     - backend
     if: 'always() &&
 
-      needs.changes.outputs.translations-only != ''true'' &&
+      github.head_ref != ''l10n/crowdin'' &&
 
       (needs.frontend.result == ''success'' || needs.frontend.result == ''skipped'') &&
 


### PR DESCRIPTION
## Bug
The `translations-only` paths-filter wrongly returned `true` for code-only PRs. In dorny/paths-filter's any-match model, the negations (`!backend/**`, `!frontend/src/**/*.tsx`) match every file that *isn't* backend / a tsx, so almost any change set the filter true. Result: **E2E silently SKIPPED on frontend code PRs** — confirmed on #329 and #330, which both merged without E2E running.

## Fix
Replace the E2E job's `translations-only != 'true'` gate with `github.head_ref != 'l10n/crowdin'`. E2E now runs for all code PRs and pushes, and skips only for the automated Crowdin translation-sync branch (whose changes are already covered by the frontend build + i18n unit tests, including the placeholder gate from #320). Removed the unused/buggy `translations-only` filter + output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)