### PR TITLE
fix(dashboard): render summary widget on the default dashboard (fixes E2E)

### DIFF
--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -435,9 +435,29 @@ async def seed_budgets(session: AsyncSession):
 
 async def seed_dashboards(session: AsyncSession):
     """Create dashboards with widgets."""
-    from sqlalchemy import insert
+    from sqlalchemy import insert, func
 
     print("Seeding dashboards...")
+
+    # The alembic migration that introduces multi-dashboard support inserts an
+    # empty "Default" dashboard (no widgets). When seeding on top of a freshly
+    # migrated database, that placeholder would otherwise remain flagged as the
+    # default *and* sort ahead of our seeded dashboard, so the app would load an
+    # empty dashboard with no Summary widget. Clear any existing default flags and
+    # drop the empty placeholder so our widget-rich dashboard becomes the canonical
+    # default (and we never leave two is_default rows behind).
+    existing_result = await session.execute(select(Dashboard))
+    for existing in existing_result.scalars().all():
+        widget_count = await session.scalar(
+            select(func.count())
+            .select_from(DashboardWidget)
+            .where(DashboardWidget.dashboard_id == existing.id)
+        )
+        if widget_count == 0:
+            await session.delete(existing)
+        else:
+            existing.is_default = False
+    await session.commit()
 
     # Default dashboard - Month to Date
     default_dashboard = Dashboard(


### PR DESCRIPTION
## Root cause

The nightly E2E dashboard suite failed because the "Total Income" summary widget never rendered on the dashboard loaded at `/`.

The CI E2E setup runs `just db::init` (alembic migrations) then `just db::seed`:

1. Migration `5a841ee04972_add_dashboards_table` inserts an **empty placeholder "Default" dashboard** (`is_default=True`, `position=0`, **zero widgets** — the `UPDATE dashboard_widgets SET dashboard_id=...` affects no rows on a fresh DB).
2. `scripts/seed.py` then created **"Monthly Overview"** (also `is_default=True`, `position=0`) **with a summary widget**.

This left two `is_default=True` rows. `GET /api/v1/dashboards` orders by `position`; with both at position 0 the empty placeholder wins the id tiebreak and sorts first. The frontend (`DashboardContext.refreshDashboards`) picks the default via `Array.find(d => d.is_default)`, which returns that **first/empty** dashboard. Its widget list is empty, so `page.tsx` renders the "no widgets" state — `SummaryCards` (and its `Total Income` label) never mounts.

PR #330 (deterministic lowest position/id default resolution) made the backend endpoints consistently prefer the empty placeholder too, which is why the failure became reliable.

## Fix

In `seed_dashboards` (`backend/scripts/seed.py`), before creating the seeded default:
- clear `is_default` on any existing dashboards, and
- delete the empty placeholder dashboard (no widgets).

So the widget-rich **"Monthly Overview"** becomes the sole, canonical default. A fresh install (`db::init` + `db::seed`) now shows a useful dashboard, and there is only ever one `is_default` row — consistent with the duplicate-default self-healing introduced in #330 (no reintroduction of that bug).

## Verification (local)

- `cd frontend && npx playwright test dashboard.spec.ts dashboard-tabs.spec.ts --project=chromium --grep @e2e` → **8 passed**, including the two previously-failing specs:
  - `dashboard.spec.ts:4` — loads and displays summary widget
  - `dashboard-tabs.spec.ts:147` — tab switch after data loads should not crash
- Negative confirmation: reconstructed the pre-fix DB state (empty Default sorting first) and the summary-widget spec **failed** exactly as in the nightly run, proving the root cause.
- DB inspection after fix: `Monthly Overview` is the sole `is_default` dashboard with 5 widgets (incl. `summary`); `Yearly View` is the second tab.
- `backend`: `uv run pytest tests/test_dashboards.py tests/test_dashboard.py` → 52 passed; `ruff check scripts/seed.py` → clean.
- `frontend`: `npx vitest run` → 552 tests passed (the only failing *suite*, `i18n.test.ts`, is a pre-existing/unrelated failure: it imports the gitignored generated `messages/pseudo.json`, absent in a fresh checkout).

## Note

E2E does not run in this PR's CI yet (re-enabling E2E-on-PRs is a separate change, #331). Local verification of the two specs is the proof here. This fix unblocks #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)