### PR TITLE
refactor(assistant): configure via environment only; drop DB columns

### DIFF
--- a/backend/alembic/versions/a2b3c4d5e6f7_drop_assistant_settings_columns.py
+++ b/backend/alembic/versions/a2b3c4d5e6f7_drop_assistant_settings_columns.py
@@ -1,0 +1,34 @@
+"""drop_assistant_settings_columns
+
+The AI assistant is now configured only via the server environment (provider,
+model, and API key). Nothing assistant-related is persisted, so drop the
+app_settings columns added by f1a2b3c4d5e6.
+
+Revision ID: a2b3c4d5e6f7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-05-26
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a2b3c4d5e6f7'
+down_revision = 'f1a2b3c4d5e6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('app_settings') as batch_op:
+        batch_op.drop_column('assistant_api_key')
+        batch_op.drop_column('assistant_model')
+        batch_op.drop_column('assistant_provider')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('app_settings') as batch_op:
+        batch_op.add_column(sa.Column('assistant_provider', sa.String(), nullable=True))
+        batch_op.add_column(sa.Column('assistant_model', sa.String(), nullable=True))
+        batch_op.add_column(sa.Column('assistant_api_key', sa.String(), nullable=True))

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,11 +36,15 @@ class AppSettings(BaseSettings):
     # CORS settings - comma-separated list of allowed origins
     cors_origins: str = "http://localhost:3000"
 
-    # AI assistant: optional API keys via environment. These are used as a
-    # fallback when no key is stored in app_settings, so a key never has to
-    # touch the database if the operator prefers env-only provisioning.
+    # AI assistant: configured entirely via environment (e.g. Docker Compose).
+    # Nothing assistant-related is persisted to the database. Provide a key for
+    # whichever provider you want; the provider auto-detects from the present
+    # key, or set assistant_provider explicitly. assistant_model is optional and
+    # defaults per provider.
     anthropic_api_key: str = ""
     openai_api_key: str = ""
+    assistant_provider: str = ""  # "anthropic" | "openai" | "" (auto-detect)
+    assistant_model: str = ""  # optional override; defaults per provider
 
     @property
     def cors_origins_list(self) -> List[str]:

--- a/backend/app/orm.py
+++ b/backend/app/orm.py
@@ -452,13 +452,8 @@ class AppSettings(TimestampMixin, Base):
     language: Mapped[str] = mapped_column(
         String, default=LanguagePreference.browser.value
     )
-
-    # AI assistant configuration (bring-your-own-key).
-    # provider is "anthropic" or "openai"; the API key is write-only and is
-    # never returned to the client (see the assistant settings endpoints).
-    assistant_provider: Mapped[Optional[str]] = mapped_column(String, nullable=True)
-    assistant_model: Mapped[Optional[str]] = mapped_column(String, nullable=True)
-    assistant_api_key: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    # NOTE: AI assistant config (provider/model/key) is intentionally NOT stored
+    # here — it is provided only via environment at startup (see app.config).
 
 
 class User(TimestampMixin, Base):

--- a/backend/app/routers/assistant.py
+++ b/backend/app/routers/assistant.py
@@ -1,9 +1,10 @@
-"""AI assistant router: configuration, chat, and approved-action execution.
+"""AI assistant router: configuration status, chat, and approved-action execution.
 
 Security posture:
 - All endpoints require an authenticated user.
-- The API key is write-only: it can be set but is never returned (the config
-  endpoint reports only whether a key is configured).
+- API keys and provider/model are configured ONLY via the server environment
+  (e.g. Docker Compose) and are never persisted or returned. The config
+  endpoint reports read-only status (provider/model/configured), never a key.
 - Chat runs read tools automatically; writes are returned as a proposal and
   only run via /execute after explicit user approval.
 """
@@ -15,7 +16,6 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings as app_config
 from app.database import get_session
 from app.errors import ErrorCode, bad_request, not_found
 from app.orm import AppSettings, LanguagePreference, User
@@ -23,6 +23,7 @@ from app.routers.auth import get_current_user
 from app.routers.settings import parse_accept_language
 from app.services.assistant import DEFAULT_MODELS, SUPPORTED_PROVIDERS
 from app.services.assistant.agent import Agent
+from app.services.assistant.env_config import resolve_assistant_config
 from app.services.assistant.providers import build_provider
 from app.services.assistant.store import (
     Conversation,
@@ -42,30 +43,16 @@ router = APIRouter(prefix="/api/v1/assistant", tags=["assistant"])
 
 
 class AssistantConfigResponse(BaseModel):
-    """Assistant configuration as seen by the client. Never includes the key."""
+    """Read-only assistant status. Reflects the server environment; no key."""
 
     provider: Optional[str] = None
     model: Optional[str] = None
-    # True when a usable key exists (stored in the DB or supplied via env).
     configured: bool = False
-    # Whether a key is present specifically in the DB (vs. env-only).
-    key_stored: bool = False
+    # How the assistant is configured. Always "env" — keys live only in the
+    # server environment, never the database or the browser.
+    source: str = "env"
     available_providers: list[str] = Field(default_factory=lambda: list(SUPPORTED_PROVIDERS))
     default_models: dict[str, str] = Field(default_factory=lambda: dict(DEFAULT_MODELS))
-
-
-class AssistantConfigUpdate(BaseModel):
-    """Update assistant configuration.
-
-    - Set ``api_key`` to a non-empty string to store a new key.
-    - Set ``clear_api_key=True`` to remove the stored key.
-    - Omitted fields are left unchanged.
-    """
-
-    provider: Optional[str] = None
-    model: Optional[str] = None
-    api_key: Optional[str] = Field(default=None, repr=False)
-    clear_api_key: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +61,7 @@ class AssistantConfigUpdate(BaseModel):
 
 
 async def _get_or_create_settings(session: AsyncSession) -> AppSettings:
+    """App settings row — used here only to read the language preference."""
     result = await session.execute(select(AppSettings))
     settings = result.scalar_one_or_none()
     if settings is None:
@@ -84,31 +72,6 @@ async def _get_or_create_settings(session: AsyncSession) -> AppSettings:
     return settings
 
 
-def _env_key_for(provider: Optional[str]) -> str:
-    """API key supplied via environment for the given provider, if any."""
-    if provider == "anthropic":
-        return app_config.anthropic_api_key
-    if provider == "openai":
-        return app_config.openai_api_key
-    return ""
-
-
-def resolve_api_key(settings: AppSettings) -> str:
-    """Effective API key: stored key wins, else the env fallback. Never returned to clients."""
-    return settings.assistant_api_key or _env_key_for(settings.assistant_provider)
-
-
-def _to_response(settings: AppSettings) -> AssistantConfigResponse:
-    key_stored = bool(settings.assistant_api_key)
-    configured = bool(resolve_api_key(settings)) and bool(settings.assistant_provider)
-    return AssistantConfigResponse(
-        provider=settings.assistant_provider,
-        model=settings.assistant_model,
-        configured=configured,
-        key_stored=key_stored,
-    )
-
-
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -117,45 +80,14 @@ def _to_response(settings: AppSettings) -> AssistantConfigResponse:
 @router.get("/config", response_model=AssistantConfigResponse)
 async def get_config(
     _user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> AssistantConfigResponse:
-    """Return assistant configuration status. Never returns the API key."""
-    settings = await _get_or_create_settings(session)
-    return _to_response(settings)
-
-
-@router.put("/config", response_model=AssistantConfigResponse)
-async def update_config(
-    updates: AssistantConfigUpdate,
-    _user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
-) -> AssistantConfigResponse:
-    """Update provider, model, and/or API key. The key is write-only."""
-    settings = await _get_or_create_settings(session)
-
-    if updates.provider is not None:
-        if updates.provider not in SUPPORTED_PROVIDERS:
-            raise bad_request(
-                ErrorCode.VALIDATION_ERROR,
-                f"Unsupported provider '{updates.provider}'. "
-                f"Choose one of: {', '.join(SUPPORTED_PROVIDERS)}.",
-            )
-        settings.assistant_provider = updates.provider
-        # Default the model when switching providers and none is set/given.
-        if updates.model is None and not settings.assistant_model:
-            settings.assistant_model = DEFAULT_MODELS.get(updates.provider)
-
-    if updates.model is not None:
-        settings.assistant_model = updates.model or None
-
-    if updates.clear_api_key:
-        settings.assistant_api_key = None
-    elif updates.api_key:
-        settings.assistant_api_key = updates.api_key
-
-    await session.commit()
-    await session.refresh(settings)
-    return _to_response(settings)
+    """Report assistant status as derived from the server environment."""
+    cfg = resolve_assistant_config()
+    return AssistantConfigResponse(
+        provider=cfg.provider,
+        model=cfg.model,
+        configured=cfg.configured,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -221,14 +153,15 @@ async def chat(
     session: AsyncSession = Depends(get_session),
 ) -> ChatResponse:
     """Send a message. Read tools run automatically; writes come back as a proposal."""
-    settings = await _get_or_create_settings(session)
-    api_key = resolve_api_key(settings)
-    if not settings.assistant_provider or not api_key:
+    cfg = resolve_assistant_config()
+    if cfg.provider is None or cfg.api_key is None:
         raise bad_request(
             ErrorCode.ASSISTANT_NOT_CONFIGURED,
-            "The assistant is not configured. Set a provider and API key first.",
+            "The assistant is not configured. Set ANTHROPIC_API_KEY or OPENAI_API_KEY "
+            "in the server environment.",
         )
-    provider = build_provider(settings.assistant_provider, api_key, settings.assistant_model)
+    provider = build_provider(cfg.provider, cfg.api_key, cfg.model)
+    settings = await _get_or_create_settings(session)  # for language preference only
     locale = _resolve_locale(settings, request)
 
     # Restore (or start) the conversation; the tokenizer lives server-side so the

--- a/backend/app/services/assistant/env_config.py
+++ b/backend/app/services/assistant/env_config.py
@@ -1,0 +1,54 @@
+"""Resolve the assistant's runtime configuration from the environment.
+
+The assistant is configured only at startup (via env / Docker Compose) — nothing
+is persisted. Provide a key for the provider you want; the provider auto-detects
+from whichever key is present, or set ``ASSISTANT_PROVIDER`` to pick explicitly.
+``ASSISTANT_MODEL`` optionally overrides the per-provider default.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from app.config import settings as app_config
+
+from . import DEFAULT_MODELS, SUPPORTED_PROVIDERS
+
+
+@dataclass
+class AssistantEnvConfig:
+    provider: Optional[str]
+    model: Optional[str]
+    api_key: Optional[str]
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.provider and self.api_key)
+
+
+def _env_key_for(provider: Optional[str]) -> str:
+    if provider == "anthropic":
+        return app_config.anthropic_api_key
+    if provider == "openai":
+        return app_config.openai_api_key
+    return ""
+
+
+def resolve_assistant_config() -> AssistantEnvConfig:
+    """Effective (provider, model, api_key) from env, or unconfigured."""
+    # Explicit provider override if valid, else auto-detect from the present key.
+    provider: Optional[str] = (app_config.assistant_provider or "").strip().lower() or None
+    if provider not in SUPPORTED_PROVIDERS:
+        provider = None
+    if provider is None:
+        if app_config.anthropic_api_key:
+            provider = "anthropic"
+        elif app_config.openai_api_key:
+            provider = "openai"
+    if provider is None:
+        return AssistantEnvConfig(provider=None, model=None, api_key=None)
+
+    api_key = _env_key_for(provider) or None
+    model = (app_config.assistant_model or "").strip() or DEFAULT_MODELS.get(provider)
+    return AssistantEnvConfig(provider=provider, model=model, api_key=api_key)

--- a/backend/tests/test_assistant.py
+++ b/backend/tests/test_assistant.py
@@ -13,7 +13,9 @@ from sqlalchemy import func, select
 from app.orm import Budget, Transaction, User
 from app.utils.auth import create_access_token, hash_password
 
+from app.config import settings as app_config
 from app.services.assistant.agent import Agent
+from app.services.assistant.env_config import resolve_assistant_config
 from app.services.assistant.prompts import build_system_prompt, language_directive
 from app.services.assistant.providers import AssistantTurn, LLMProvider, ToolCall
 from app.services.assistant.store import Proposal, ProposedAction, proposals
@@ -258,40 +260,60 @@ class TestExecuteEndpoint:
 
 
 # ---------------------------------------------------------------------------
-# Config endpoint: key is write-only, provider validated, auth required
+# Env-only configuration: resolver + read-only status endpoint
 # ---------------------------------------------------------------------------
+
+
+def _set_env(monkeypatch, *, anthropic="", openai="", provider="", model=""):
+    monkeypatch.setattr(app_config, "anthropic_api_key", anthropic)
+    monkeypatch.setattr(app_config, "openai_api_key", openai)
+    monkeypatch.setattr(app_config, "assistant_provider", provider)
+    monkeypatch.setattr(app_config, "assistant_model", model)
+
+
+class TestEnvConfig:
+    def test_unconfigured_when_no_keys(self, monkeypatch):
+        _set_env(monkeypatch)
+        cfg = resolve_assistant_config()
+        assert cfg.configured is False
+        assert cfg.provider is None
+
+    def test_autodetects_anthropic_with_default_model(self, monkeypatch):
+        _set_env(monkeypatch, anthropic="sk-a")
+        cfg = resolve_assistant_config()
+        assert cfg.configured is True
+        assert cfg.provider == "anthropic"
+        assert cfg.model == "claude-sonnet-4-6"
+
+    def test_explicit_provider_and_model_override(self, monkeypatch):
+        _set_env(monkeypatch, openai="sk-o", provider="openai", model="gpt-4.1")
+        cfg = resolve_assistant_config()
+        assert cfg.provider == "openai"
+        assert cfg.model == "gpt-4.1"
 
 
 class TestConfigEndpoint:
     async def test_requires_auth(self, client):
         assert (await client.get("/api/v1/assistant/config")).status_code == 401
 
-    async def test_set_key_is_write_only(self, client, auth_headers):
-        resp = await client.put(
-            "/api/v1/assistant/config",
-            json={"provider": "anthropic", "api_key": "sk-secret-123", "model": "claude-sonnet-4-6"},
-            headers=auth_headers,
-        )
-        assert resp.status_code == 200, resp.text
-        body = resp.json()
-        assert body["configured"] is True
-        assert body["key_stored"] is True
-        # The key must never be echoed back anywhere in the payload.
-        assert "sk-secret-123" not in json.dumps(body)
-        assert "api_key" not in body
-
+    async def test_reports_status_from_env_without_leaking_key(self, client, auth_headers, monkeypatch):
+        _set_env(monkeypatch, anthropic="sk-secret-123")
         got = (await client.get("/api/v1/assistant/config", headers=auth_headers)).json()
+        assert got["configured"] is True
         assert got["provider"] == "anthropic"
+        assert got["source"] == "env"
+        # The key must never appear anywhere in the payload.
         assert "sk-secret-123" not in json.dumps(got)
+        assert "api_key" not in json.dumps(got)
 
-    async def test_invalid_provider_rejected(self, client, auth_headers):
-        resp = await client.put(
-            "/api/v1/assistant/config", json={"provider": "bogus"}, headers=auth_headers
-        )
-        assert resp.status_code == 400
+    async def test_reports_not_configured(self, client, auth_headers, monkeypatch):
+        _set_env(monkeypatch)
+        got = (await client.get("/api/v1/assistant/config", headers=auth_headers)).json()
+        assert got["configured"] is False
 
-    async def test_chat_requires_configuration(self, client, auth_headers):
-        """With no provider/key configured, chat returns a clear 'not configured' error."""
+    async def test_chat_requires_configuration(self, client, auth_headers, monkeypatch):
+        """With nothing in the environment, chat returns a clear 'not configured' error."""
+        _set_env(monkeypatch)
         resp = await client.post(
             "/api/v1/assistant/chat", json={"message": "hi"}, headers=auth_headers
         )

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -29,6 +29,13 @@ services:
       - DATABASE_URL=sqlite+aiosqlite:////data/wallet.db
       - DEMO_MODE=${DEMO_MODE:-false}
       - DEMO_RESET_INTERVAL_HOURS=${DEMO_RESET_INTERVAL_HOURS:-1}
+      # AI assistant — configured only via env, nothing persisted. Provide a key
+      # for the provider you want; provider auto-detects from the key present, or
+      # set ASSISTANT_PROVIDER / ASSISTANT_MODEL to override.
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - ASSISTANT_PROVIDER=${ASSISTANT_PROVIDER:-}
+      - ASSISTANT_MODEL=${ASSISTANT_MODEL:-}
       # Observability
       - OTEL_ENABLED=true
       - OTEL_METRICS_ENABLED=true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,13 @@ services:
       - wallet-data:/data
     environment:
       - DATABASE_URL=sqlite+aiosqlite:////data/wallet.db
+      # AI assistant (optional) — configured only via env, nothing persisted.
+      # Provide a key for the provider you want; provider auto-detects from the
+      # key present, or set ASSISTANT_PROVIDER / ASSISTANT_MODEL to override.
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - ASSISTANT_PROVIDER=${ASSISTANT_PROVIDER:-}
+      - ASSISTANT_MODEL=${ASSISTANT_MODEL:-}
     restart: unless-stopped
 
 volumes:

--- a/frontend/src/app/(main)/assistant/page.tsx
+++ b/frontend/src/app/(main)/assistant/page.tsx
@@ -84,15 +84,7 @@ export default function AssistantPage() {
         </button>
       </header>
 
-      {showSettings && config && (
-        <AssistantSettings
-          config={config}
-          onSaved={(c) => {
-            setConfig(c)
-            if (c.configured) setShowSettings(false)
-          }}
-        />
-      )}
+      {showSettings && config && <AssistantSettings config={config} />}
 
       {config && !config.configured && !showSettings && (
         <p data-testid={TEST_IDS.ASSISTANT_NOT_CONFIGURED} className="text-sm text-amber-700 dark:text-amber-400">

--- a/frontend/src/components/assistant/AssistantSettings.test.tsx
+++ b/frontend/src/components/assistant/AssistantSettings.test.tsx
@@ -1,58 +1,39 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
 import { AssistantSettings } from './AssistantSettings'
 import { TEST_IDS } from '@/test-ids'
 import type { AssistantConfig } from '@/lib/assistant'
-
-const updateAssistantConfig = vi.fn()
-vi.mock('@/lib/assistant', () => ({
-  updateAssistantConfig: (...args: unknown[]) => updateAssistantConfig(...args),
-}))
 
 const baseConfig: AssistantConfig = {
   provider: null,
   model: null,
   configured: false,
-  key_stored: false,
+  source: 'env',
   available_providers: ['anthropic', 'openai'],
   default_models: { anthropic: 'claude-sonnet-4-6', openai: 'gpt-4o' },
 }
 
-describe('AssistantSettings', () => {
-  beforeEach(() => {
-    updateAssistantConfig.mockReset()
-  })
-
-  it('saves provider + key and clears the key field afterward', async () => {
-    updateAssistantConfig.mockResolvedValue({ ...baseConfig, provider: 'anthropic', configured: true, key_stored: true })
-    const onSaved = vi.fn()
-    render(<AssistantSettings config={baseConfig} onSaved={onSaved} />)
-
-    const keyInput = screen.getByTestId(TEST_IDS.ASSISTANT_KEY_INPUT) as HTMLInputElement
-    // The key field is a password input (write-only UI).
-    expect(keyInput.type).toBe('password')
-
-    fireEvent.change(keyInput, { target: { value: 'sk-secret' } })
-    fireEvent.click(screen.getByTestId(TEST_IDS.ASSISTANT_SETTINGS_SAVE))
-
-    await waitFor(() =>
-      expect(updateAssistantConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: 'anthropic', api_key: 'sk-secret' }),
-      ),
+describe('AssistantSettings (read-only status)', () => {
+  it('shows provider and model when configured via env', () => {
+    render(
+      <AssistantSettings
+        config={{ ...baseConfig, configured: true, provider: 'anthropic', model: 'claude-sonnet-4-6' }}
+      />,
     )
-    await waitFor(() => expect(onSaved).toHaveBeenCalled())
-    // Key field cleared after save so the secret isn't left in the DOM.
-    expect(keyInput.value).toBe('')
+    expect(screen.getByTestId(TEST_IDS.ASSISTANT_SETTINGS_STATUS)).toHaveTextContent(/configured/i)
+    expect(screen.getByText('anthropic')).toBeInTheDocument()
+    expect(screen.getByText('claude-sonnet-4-6')).toBeInTheDocument()
   })
 
-  it('does not send api_key when the field is left blank', async () => {
-    updateAssistantConfig.mockResolvedValue({ ...baseConfig, configured: true })
-    render(<AssistantSettings config={{ ...baseConfig, key_stored: true, provider: 'anthropic' }} onSaved={vi.fn()} />)
+  it('shows guidance when not configured', () => {
+    render(<AssistantSettings config={baseConfig} />)
+    expect(screen.getByTestId(TEST_IDS.ASSISTANT_SETTINGS_STATUS)).toHaveTextContent(/not configured/i)
+    expect(screen.getByText(/ANTHROPIC_API_KEY/)).toBeInTheDocument()
+  })
 
-    fireEvent.click(screen.getByTestId(TEST_IDS.ASSISTANT_SETTINGS_SAVE))
-
-    await waitFor(() => expect(updateAssistantConfig).toHaveBeenCalled())
-    const arg = updateAssistantConfig.mock.calls[0][0]
-    expect(arg.api_key).toBeUndefined()
+  it('never renders a key input or save control (env-only config)', () => {
+    const { container } = render(<AssistantSettings config={baseConfig} />)
+    expect(container.querySelector('input[type="password"]')).toBeNull()
+    expect(screen.queryByRole('button')).toBeNull()
   })
 })

--- a/frontend/src/components/assistant/AssistantSettings.tsx
+++ b/frontend/src/components/assistant/AssistantSettings.tsx
@@ -1,56 +1,27 @@
 'use client'
 
-import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { TEST_IDS } from '@/test-ids'
-import {
-  updateAssistantConfig,
-  type AssistantConfig,
-} from '@/lib/assistant'
+import type { AssistantConfig } from '@/lib/assistant'
 
 interface AssistantSettingsProps {
   config: AssistantConfig
-  onSaved: (config: AssistantConfig) => void
 }
 
 /**
- * Configure the BYOK provider/model/key. The API key is write-only: the server
- * never returns it, so this form only ever sends a new one (or clears it).
+ * Read-only status panel. The assistant is configured entirely via the server
+ * environment (ANTHROPIC_API_KEY / OPENAI_API_KEY, optional ASSISTANT_PROVIDER /
+ * ASSISTANT_MODEL) — there is no key entry here and nothing is stored.
  */
-export function AssistantSettings({ config, onSaved }: AssistantSettingsProps) {
+export function AssistantSettings({ config }: AssistantSettingsProps) {
   const t = useTranslations('assistant.settings')
-  const [provider, setProvider] = useState(config.provider ?? config.available_providers[0] ?? 'anthropic')
-  const [model, setModel] = useState(config.model ?? '')
-  const [apiKey, setApiKey] = useState('')
-  const [saving, setSaving] = useState(false)
-  const [saved, setSaved] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  async function handleSave() {
-    setSaving(true)
-    setSaved(false)
-    setError(null)
-    try {
-      const updated = await updateAssistantConfig({
-        provider,
-        model: model || undefined,
-        api_key: apiKey || undefined,
-      })
-      setApiKey('')
-      setSaved(true)
-      onSaved(updated)
-    } catch (e) {
-      setError((e as Error).message)
-    } finally {
-      setSaving(false)
-    }
-  }
 
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
       <div className="flex items-center justify-between">
         <h3 className="font-semibold text-gray-900 dark:text-gray-100">{t('title')}</h3>
         <span
+          data-testid={TEST_IDS.ASSISTANT_SETTINGS_STATUS}
           className={
             config.configured
               ? 'rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/40 dark:text-green-300'
@@ -61,69 +32,18 @@ export function AssistantSettings({ config, onSaved }: AssistantSettingsProps) {
         </span>
       </div>
 
-      <div className="mt-4 grid gap-4 sm:grid-cols-2">
-        <label className="text-sm">
-          <span className="mb-1 block font-medium text-gray-700 dark:text-gray-200">{t('provider')}</span>
-          <select
-            data-testid={TEST_IDS.ASSISTANT_PROVIDER_SELECT}
-            data-chaos-exclude
-            value={provider}
-            onChange={(e) => {
-              setProvider(e.target.value)
-              // Suggest the provider's default model if the box is empty.
-              if (!model) setModel(config.default_models[e.target.value] ?? '')
-            }}
-            className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-gray-800"
-          >
-            {config.available_providers.map((p) => (
-              <option key={p} value={p}>
-                {p}
-              </option>
-            ))}
-          </select>
-        </label>
+      {config.configured ? (
+        <dl className="mt-3 grid grid-cols-[auto,1fr] gap-x-4 gap-y-1 text-sm">
+          <dt className="text-gray-500 dark:text-gray-400">{t('provider')}</dt>
+          <dd className="font-medium text-gray-900 dark:text-gray-100">{config.provider}</dd>
+          <dt className="text-gray-500 dark:text-gray-400">{t('model')}</dt>
+          <dd className="font-medium text-gray-900 dark:text-gray-100">{config.model}</dd>
+        </dl>
+      ) : (
+        <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">{t('notConfiguredHelp')}</p>
+      )}
 
-        <label className="text-sm">
-          <span className="mb-1 block font-medium text-gray-700 dark:text-gray-200">{t('model')}</span>
-          <input
-            data-testid={TEST_IDS.ASSISTANT_MODEL_INPUT}
-            type="text"
-            value={model}
-            onChange={(e) => setModel(e.target.value)}
-            placeholder={config.default_models[provider] ?? ''}
-            className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-gray-800"
-          />
-        </label>
-      </div>
-
-      <label className="mt-4 block text-sm">
-        <span className="mb-1 block font-medium text-gray-700 dark:text-gray-200">{t('apiKey')}</span>
-        <input
-          data-testid={TEST_IDS.ASSISTANT_KEY_INPUT}
-          type="password"
-          autoComplete="off"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          placeholder={config.key_stored ? t('apiKeyStored') : t('apiKeyPlaceholder')}
-          className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-gray-800"
-        />
-        <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">{t('keyNeverShown')}</span>
-      </label>
-
-      <div className="mt-4 flex items-center gap-3">
-        <button
-          type="button"
-          data-testid={TEST_IDS.ASSISTANT_SETTINGS_SAVE}
-          data-chaos-exclude
-          onClick={handleSave}
-          disabled={saving}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
-        >
-          {t('save')}
-        </button>
-        {saved && <span className="text-sm text-green-700 dark:text-green-400">{t('saved')}</span>}
-        {error && <span className="text-sm text-red-600 dark:text-red-400">{error}</span>}
-      </div>
+      <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">{t('envManaged')}</p>
     </div>
   )
 }

--- a/frontend/src/lib/assistant.ts
+++ b/frontend/src/lib/assistant.ts
@@ -12,16 +12,11 @@ export interface AssistantConfig {
   provider: string | null
   model: string | null
   configured: boolean
-  key_stored: boolean
+  // How it's configured. Always "env" — keys live only in the server
+  // environment, never the database or the browser.
+  source: string
   available_providers: string[]
   default_models: Record<string, string>
-}
-
-export interface AssistantConfigUpdate {
-  provider?: string
-  model?: string
-  api_key?: string
-  clear_api_key?: boolean
 }
 
 export interface ProposedAction {
@@ -77,10 +72,6 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
 export function getAssistantConfig(): Promise<AssistantConfig> {
   return request<AssistantConfig>('/config')
-}
-
-export function updateAssistantConfig(update: AssistantConfigUpdate): Promise<AssistantConfig> {
-  return request<AssistantConfig>('/config', { method: 'PUT', body: JSON.stringify(update) })
 }
 
 export function sendChat(message: string, conversationId: string | null): Promise<ChatResponse> {

--- a/frontend/src/messages/en-US.json
+++ b/frontend/src/messages/en-US.json
@@ -1010,13 +1010,8 @@
       "notConfigured": "Not configured",
       "provider": "Provider",
       "model": "Model",
-      "apiKey": "API key",
-      "apiKeyStored": "A key is saved. Leave blank to keep it.",
-      "apiKeyPlaceholder": "Paste your API key",
-      "save": "Save",
-      "saved": "Saved.",
-      "clearKey": "Remove saved key",
-      "keyNeverShown": "Your key is stored on the server and never shown again or sent to the browser."
+      "notConfiguredHelp": "Set ANTHROPIC_API_KEY or OPENAI_API_KEY in the server environment to enable the assistant.",
+      "envManaged": "Configured on the server via environment variables. No keys are stored or entered here."
     }
   }
 }

--- a/frontend/src/test-ids/assistant.ts
+++ b/frontend/src/test-ids/assistant.ts
@@ -15,10 +15,7 @@ export const ASSISTANT_IDS = {
   ASSISTANT_PROPOSAL_EXECUTE: 'assistant-proposal-execute',
   ASSISTANT_PROPOSAL_CANCEL: 'assistant-proposal-cancel',
 
-  // Settings (provider / model / key)
+  // Settings (read-only status; configured via server env)
   ASSISTANT_SETTINGS_TOGGLE: 'assistant-settings-toggle',
-  ASSISTANT_PROVIDER_SELECT: 'assistant-provider-select',
-  ASSISTANT_MODEL_INPUT: 'assistant-model-input',
-  ASSISTANT_KEY_INPUT: 'assistant-key-input',
-  ASSISTANT_SETTINGS_SAVE: 'assistant-settings-save',
+  ASSISTANT_SETTINGS_STATUS: 'assistant-settings-status',
 } as const;


### PR DESCRIPTION
## Summary

Follow-up to #335. Moves **all** AI-assistant configuration to the server **environment** and stops persisting anything. The API key never touches the database or the browser.

Motivation: a provider key at rest in the DB isn't wanted — config should be passed in at startup (Docker Compose).

## What changed

- **Env-only config.** `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` (+ optional `ASSISTANT_PROVIDER`, `ASSISTANT_MODEL`). The provider **auto-detects** from whichever key is present, or set `ASSISTANT_PROVIDER` to choose. Model defaults per provider.
- **DB columns dropped.** New migration removes `app_settings.assistant_provider/model/api_key` (added in #335). Resolver lives in `app/services/assistant/env_config.py`.
- **`/config` is read-only status** — returns `provider`, `model`, `configured`, `source: "env"`; never a key. **`PUT /config` removed.** Chat builds the provider from env and returns `ASSISTANT_NOT_CONFIGURED` when nothing is set.
- **Frontend settings panel → read-only status** (shows configured/provider/model, or guidance to set the env var). No key field, no save. `updateAssistantConfig` removed from the API client; en-US strings updated.
- **Compose** passes the vars to the backend via `${VAR:-}` in `docker-compose.yaml` and `docker-compose.dev.yaml`.

## Configure

```yaml
environment:
  - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
  - OPENAI_API_KEY=${OPENAI_API_KEY:-}
  - ASSISTANT_PROVIDER=${ASSISTANT_PROVIDER:-}   # optional; auto-detects otherwise
  - ASSISTANT_MODEL=${ASSISTANT_MODEL:-}         # optional; per-provider default
```
Set the key in your shell or a repo-root `.env`, then rebuild.

## Tests

- Backend (**1181 pass**, ruff + mypy clean): env resolver (unconfigured / auto-detect anthropic + default model / explicit provider+model), `/config` reports env status **without leaking the key**, chat returns not-configured when unset. Plus the existing tokenizer / allowlist / propose-not-execute / execute-revalidation suite.
- Frontend: read-only `AssistantSettings` (shows status; **never renders a key input or save control**); tsc + eslint clean.

> Note: the unrelated `i18n.test.ts` locale-completeness check is red on `main` already (assistant source strings awaiting Crowdin translation) — tracked separately, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
