### PR TITLE
fix(i18n): English fallback + non-blocking completeness gate on code PRs

### DIFF
--- a/frontend/src/components/ProtectedProviders.tsx
+++ b/frontend/src/components/ProtectedProviders.tsx
@@ -9,6 +9,7 @@ import { DemoModeProvider } from '@/contexts/DemoModeContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { defaultLocale, Locale, isValidLocale } from '@/i18n'
 import universal from '@/messages/universal.json'
+import enUS from '@/messages/en-US.json'
 import { useRouter } from 'next/navigation'
 
 // Deep merge objects (universal strings override locale strings)
@@ -35,9 +36,14 @@ async function loadMessages(locale: string): Promise<Record<string, unknown>> {
   // skip the universal merge for pseudo.
   const mergeUniversal = (msgs: Record<string, unknown>) =>
     locale === 'pseudo' ? msgs : deepMerge(msgs, universal)
+  // Layer en-US underneath so any key a locale is missing falls back to English
+  // at runtime instead of rendering the raw key path. Skip pseudo (it must stay
+  // fully transformed for the coverage tests).
+  const withEnglishBase = (msgs: Record<string, unknown>) =>
+    locale === 'pseudo' ? msgs : deepMerge(enUS as Record<string, unknown>, msgs)
   try {
     const localeMessages = (await import(`@/messages/${locale}.json`)).default
-    return mergeUniversal(localeMessages)
+    return mergeUniversal(withEnglishBase(localeMessages))
   } catch {
     // Fallback to default locale if message file not found
     console.warn(`Messages for locale "${locale}" not found, falling back to ${defaultLocale}`)

--- a/frontend/src/components/Providers.tsx
+++ b/frontend/src/components/Providers.tsx
@@ -7,6 +7,7 @@ import { DashboardProvider } from '@/contexts/DashboardContext'
 import { DemoModeProvider } from '@/contexts/DemoModeContext'
 import { defaultLocale, Locale, isValidLocale } from '@/i18n'
 import universal from '@/messages/universal.json'
+import enUS from '@/messages/en-US.json'
 
 // Deep merge objects (universal strings override locale strings)
 function deepMerge(base: Record<string, unknown>, override: Record<string, unknown>): Record<string, unknown> {
@@ -32,9 +33,14 @@ async function loadMessages(locale: string): Promise<Record<string, unknown>> {
   // skip the universal merge for pseudo.
   const mergeUniversal = (msgs: Record<string, unknown>) =>
     locale === 'pseudo' ? msgs : deepMerge(msgs, universal)
+  // Layer en-US underneath so any key a locale is missing falls back to English
+  // at runtime instead of rendering the raw key path. Skip pseudo (it must stay
+  // fully transformed for the coverage tests).
+  const withEnglishBase = (msgs: Record<string, unknown>) =>
+    locale === 'pseudo' ? msgs : deepMerge(enUS as Record<string, unknown>, msgs)
   try {
     const localeMessages = (await import(`@/messages/${locale}.json`)).default
-    return mergeUniversal(localeMessages)
+    return mergeUniversal(withEnglishBase(localeMessages))
   } catch {
     // Fallback to default locale if message file not found
     console.warn(`Messages for locale "${locale}" not found, falling back to ${defaultLocale}`)

--- a/frontend/src/test/i18n.test.ts
+++ b/frontend/src/test/i18n.test.ts
@@ -154,6 +154,24 @@ function findPlaceholderMismatches(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const UNIVERSAL_STRINGS = new Set(getAllKeys(universal as Record<string, unknown>))
 
+/**
+ * Whether missing-key completeness is a HARD failure.
+ *
+ * Runtime safety no longer depends on locale completeness: the app layers en-US
+ * underneath every locale (see Providers/ProtectedProviders), so a missing key
+ * renders in English rather than breaking. Completeness is therefore a
+ * translation-quality gate, not a correctness gate.
+ *
+ * We enforce it strictly only where it must hold — the Crowdin sync PR
+ * (head ref `l10n/crowdin`), which is the change that's supposed to deliver
+ * complete translations — or when explicitly requested via I18N_STRICT=1.
+ * On ordinary feature PRs (which legitimately add en-US strings ahead of
+ * translation) it's a non-blocking warning, so adding a string never turns a
+ * code PR red. Placeholder integrity (below) is always a hard failure.
+ */
+const STRICT_I18N =
+  process.env.I18N_STRICT === '1' || process.env.GITHUB_HEAD_REF === 'l10n/crowdin'
+
 
 describe('i18n translations', () => {
   const sourceKeys = new Set(getAllKeys(enUS))
@@ -180,11 +198,16 @@ describe('i18n translations', () => {
       it(`${locale}: has every key from en-US.json`, () => {
         const missing = [...sourceKeys].filter((key) => !localeKeys.has(key))
         if (missing.length > 0) {
-          throw new Error(
+          const message =
             `${locale}.json is missing ${missing.length} key(s) from en-US.json ` +
             `(run the Crowdin Sync workflow to pull translations):\n` +
             missing.map((k) => `  - ${k}`).join('\n')
-          )
+          if (STRICT_I18N) {
+            throw new Error(message)
+          }
+          // Non-blocking on code PRs: en-US fallback covers these at runtime;
+          // the Crowdin sync PR (l10n/crowdin) enforces completeness strictly.
+          console.warn(`[i18n] ${message}`)
         }
       })
 


### PR DESCRIPTION
## Summary

Stops the recurring i18n friction **by default**: a PR that adds `en-US` source strings used to turn the required Frontend check red (and risk shipping broken locales) until Crowdin caught up. This makes incomplete locales *safe* and the completeness check non-blocking on code PRs, while still enforcing completeness where it must hold — the Crowdin sync PR.

## Changes

**1. Per-key English fallback (runtime safety).**
`Providers.tsx` / `ProtectedProviders.tsx` now layer `en-US` underneath each locale (`deepMerge(enUS, localeMessages)`). Any key a locale is missing renders in **English** instead of the raw key path. The `pseudo` locale is skipped (it must stay fully transformed). Complete locales are unaffected — locale strings still override the English base.

**2. Completeness gate becomes context-aware.**
The "shipped locales have every en-US key" test now hard-fails only when **strict**:
- `GITHUB_HEAD_REF === 'l10n/crowdin'` (the Crowdin sync PR — the change that's *supposed* to deliver complete translations), or
- `I18N_STRICT=1`.

On ordinary code PRs it's a **non-blocking `console.warn`**. **Placeholder-integrity** (`{count}` etc.) stays a hard failure everywhere — that catches real render-time bugs.

## Why this is safe
Runtime correctness no longer depends on locale parity (the fallback covers it), so completeness is a *translation-quality* gate, not a *correctness* gate — and it's still strictly enforced on the sync PR. Net effect: adding a string never reds a code PR or blocks merge, and `main` never ships broken locales.

## Verification
- Soft mode (code PR): full frontend suite **578/578 pass** (incl. both message loaders, with assistant source keys not yet translated).
- Strict mode (`I18N_STRICT=1`): completeness still **fails** on incomplete locales — the `l10n/crowdin` gate is intact.
- `tsc` + `eslint` clean.

## Follow-up (not in this PR)
Full **hands-free Crowdin auto-sync** (upload → pre-translate → download → PR on push to main) needs the project's MT/AI engine id — pending a Crowdin token. This PR removes the *blocking* friction now; auto-translation cadence is the separate next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
