### PR TITLE
ci(i18n): pull Crowdin translations daily instead of weekly

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -5,9 +5,12 @@ name: Crowdin Sync
 # pinned, and debuggable.
 #
 #   - On push to main that touches en-US.json (the only source file), we push
-#     the updated source strings up to Crowdin.
-#   - On a weekly schedule (and on-demand via "Run workflow"), we pull completed
-#     translations down and open a PR onto main.
+#     the updated source strings up to Crowdin. A Crowdin project Automation
+#     ("Pre-translate via MT/AI" on source update) then translates them async.
+#   - On a daily schedule (and on-demand via "Run workflow"), we pull completed
+#     translations down and open a PR onto main, which Crowdin Auto-merge lands.
+#     So adding a source string flows to translated locales hands-free within a
+#     day, no manual step.
 #
 # Config (file mapping, project id) lives in crowdin.yaml at the repo root.
 # Secret: CROWDIN_PERSONAL_TOKEN (already set in repo secrets).
@@ -20,8 +23,10 @@ name: Crowdin Sync
       - frontend/src/messages/en-US.json
       - crowdin.yaml
   schedule:
-    # Mondays 06:00 UTC — pull whatever translations are ready and open a PR.
-    - cron: "0 6 * * 1"
+    # Daily 06:00 UTC — pull whatever translations are ready and open a PR.
+    # Daily (vs. weekly) so a merged source-string change reaches translated
+    # locales within a day once the Crowdin pre-translate Automation has run.
+    - cron: "0 6 * * *"
   workflow_dispatch:
     # Manual trigger. Use this for the first sync after enabling the Action.
     inputs:


### PR DESCRIPTION
Tightens the Crowdin sync cadence so translations land hands-free.

With a Crowdin **Pre-translate Automation** enabled on the project (translate new source strings via MT/AI on upload), the flow becomes fully automatic:

`merge en-US change → push uploads sources → Crowdin auto-pre-translates (async) → daily download opens the l10n/crowdin PR → Crowdin Auto-merge lands it`

Only change: schedule `cron` weekly (`0 6 * * 1`) → daily (`0 6 * * *`). Push=upload and manual dispatch=download are unchanged. So a merged source-string change reaches translated locales within a day instead of up to a week, with no manual step.

Pairs with #339 (English fallback + non-blocking completeness gate), which removes the merge-blocking friction immediately; this removes the manual-pull friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)