### PR TITLE
fix(docker): build the image natively on arm64 (install arch-matched @next/swc)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,17 @@ WORKDIR /app/frontend
 # Install production dependencies only (skip devDependencies like crowdin-context-harvester
 # which pulls vscode-ripgrep that downloads binaries from GitHub CDN - often flaky)
 COPY frontend/package.json frontend/package-lock.json* ./
-RUN npm ci --omit=dev
+# `npm ci` can miss the platform-specific @next/swc native binary, because a
+# package-lock.json generated on one OS/arch may not record optional deps for
+# others. Next 16's Turbopack build *requires* the native binding (it rejects
+# the WASM fallback), so explicitly install the one matching THIS build arch.
+# node's process.arch ("x64"/"arm64") maps directly to the @next/swc suffix;
+# node:22-slim is glibc (Debian), hence the "-gnu" variant. Builds natively on
+# both linux/amd64 and linux/arm64 — no emulation needed.
+RUN npm ci --omit=dev \
+    && SWC_ARCH="$(node -p process.arch)" \
+    && NEXT_VER="$(node -p "require('next/package.json').version")" \
+    && npm install --no-save "@next/swc-linux-${SWC_ARCH}-gnu@${NEXT_VER}"
 
 # Copy frontend source and build
 COPY frontend/ ./


### PR DESCRIPTION
## Problem
The dev image build (`docker compose -f docker-compose.dev.yaml build`) failed on Apple Silicon:
```
Error: Turbopack is not supported on this platform (linux/arm64) because native bindings are not available.
```
Next 16's `next build` uses Turbopack, which **requires** the native `@next/swc` binding and rejects the WASM fallback. `npm ci` didn't install `@next/swc-linux-arm64-gnu` in the container — a known npm gap where a `package-lock.json` generated on one OS/arch doesn't record optional deps for other platforms.

**Why CI was green:** CI runs on `ubuntu-latest` (linux/amd64), where the amd64 binding installs fine. Only the arm64 (Apple Silicon) build hit the gap.

## Fix
After `npm ci`, install the `@next/swc` binary matching the build arch:
```dockerfile
RUN npm ci --omit=dev \
    && SWC_ARCH="$(node -p process.arch)" \
    && NEXT_VER="$(node -p "require('next/package.json').version")" \
    && npm install --no-save "@next/swc-linux-${SWC_ARCH}-gnu@${NEXT_VER}"
```
`process.arch` → `x64` on amd64, `arm64` on arm64; node:22-slim is glibc, hence `-gnu`. **Builds natively on both arches — no emulation or platform pin.**

## Verified
- Native build succeeds; `docker image inspect` → `arm64/linux`.
- Turbopack build (`frontend-builder 8/8`) completes (previously failed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)