### PR TITLE
release: v1.0.0 — docs overhaul + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-26
+
+First stable release. Maxwell's Wallet 1.0 ships the full feature set: CSV/QFX/QIF import, transaction management, budgets, customizable dashboards, analytics, recurring detection, transfer detection, tagging, single-user authentication, the new AI assistant, 10-language internationalization, and built-in observability.
+
+### Added
+- **AI Assistant (bring-your-own-key)** - In-app chat assistant backed by Anthropic (Claude) or OpenAI, configured entirely via server environment variables (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`, optional `ASSISTANT_PROVIDER`/`ASSISTANT_MODEL`) — nothing is persisted (PRs #335, #338)
+  - **Privacy-preserving** - Reversible PII tokenization so account, merchant, and person names never leave the machine
+  - **Read-only insights** - Answers questions about your finances without modifying data
+  - **Propose-and-approve** - Proposes changes you approve before they run, limited to budgets, categorization (tags), and dashboards; it cannot touch transactions, transfers, imports, accounts, or settings
+  - **Localized replies** - Responds in your selected language
+
+### Changed
+- **i18n Resilience** - Per-key English fallback so a missing translation renders in English instead of breaking the UI; Crowdin translations are now pulled daily instead of weekly (#339, #340)
+- **Docker Multi-Arch Builds** - Docker image now builds natively on both linux/arm64 and linux/amd64 by installing the arch-matched `@next/swc` binding so Next 16's Turbopack build works on each platform (#341)
+- **CI Multi-Arch Coverage** - CI now also builds the image on arm64, so arch-specific build breaks fail CI instead of slipping through (#342)
+
+### Fixed
+- **Locale Completeness Gate** - The locale-completeness CI gate is now non-blocking on code PRs and strict only on the Crowdin sync PR, so missing in-progress translations no longer block unrelated work (#339, #340)
+
 ## [0.11.0] - 2026-01-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,15 +13,20 @@ Personal finance tracker with CSV import, smart categorization, and spending tre
 
 **[Documentation](https://docs.maxwellswallet.com)** · **[Requirements](docs/requirements/)**
 
-## What's New in v0.11
+## What's New in v1.0
 
-### SQLAlchemy 2.0 Migration
-- **ORM Upgrade** - Migrated from SQLModel to SQLAlchemy 2.0 + Pydantic for improved type safety and performance
+Maxwell's Wallet 1.0 is the first stable release, bringing the full feature set together: CSV/QFX/QIF import, transactions, budgets, dashboards, analytics, recurring detection, transfers, tagging, single-user auth, 10-language i18n, observability — and the new AI Assistant.
 
-### Performance & Stability
-- **Transactions Page** - Debouncing and request cancellation prevent UI lag during rapid filtering
-- **Chaos Tests** - Viewport-based demon mode interactions for reliable stress testing
-- **Docker Builds** - Skip devDependencies to avoid flaky downloads
+### AI Assistant (Bring Your Own Key)
+- **In-App Chat** - Ask questions about your finances and get answers powered by Anthropic (Claude) or OpenAI
+- **Privacy-Preserving** - Reversible PII tokenization keeps account, merchant, and person names on your machine
+- **Propose-and-Approve** - The assistant proposes changes you approve before they run, limited to budgets, categorization, and dashboards (never transactions, transfers, imports, accounts, or settings)
+- **Configured via Environment** - Bring your own key; nothing is stored
+- **Speaks Your Language** - Replies in your selected locale
+
+### Reliability
+- **i18n Fallback** - Missing translations render in English instead of breaking the UI; Crowdin translations now sync daily
+- **Multi-Arch Docker** - Image builds natively on both linux/arm64 and linux/amd64, with arm64 now covered in CI
 
 See [CHANGELOG.md](CHANGELOG.md) for full release history.
 
@@ -40,6 +45,11 @@ See [CHANGELOG.md](CHANGELOG.md) for full release history.
 - **Anomaly Detection**: Flag unusual purchases, new merchants, and budget leaks
 - **Month-over-Month**: Track spending changes with category-level breakdown
 - **Daily Burn Rate**: Know early if you're on track to overspend
+
+### AI Assistant
+- **Bring Your Own Key**: In-app chat backed by Anthropic (Claude) or OpenAI, configured via environment variables (keys are never stored)
+- **Privacy-Preserving**: Reversible PII tokenization keeps account, merchant, and person names on your machine
+- **Propose-and-Approve**: Read-only insights plus changes you approve before they run, limited to budgets, categorization, and dashboards
 
 ### Search & Filtering
 - **Quick Filters**: One-click buttons for This Month, Last Month, Large, Unreconciled
@@ -114,6 +124,25 @@ Set `SECRET_KEY` in production for JWT signing (defaults to dev key):
 ```bash
 docker run -d -p 3000:3000 -p 3001:3001 \
   -e SECRET_KEY="your-secure-random-string" \
+  -v /path/to/data:/data \
+  ghcr.io/poindexter12/maxwells-wallet
+```
+
+### AI Assistant (Optional)
+
+The AI Assistant uses your own API key, supplied via environment variables. Keys are read from the environment only and are never stored.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ANTHROPIC_API_KEY` | One of these | API key for Anthropic (Claude) |
+| `OPENAI_API_KEY` | One of these | API key for OpenAI |
+| `ASSISTANT_PROVIDER` | Optional | Provider to use (`anthropic` or `openai`) |
+| `ASSISTANT_MODEL` | Optional | Override the default model |
+
+```bash
+docker run -d -p 3000:3000 -p 3001:3001 \
+  -e SECRET_KEY="your-secure-random-string" \
+  -e ANTHROPIC_API_KEY="sk-ant-..." \
   -v /path/to/data:/data \
   ghcr.io/poindexter12/maxwells-wallet
 ```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maxwells-wallet-backend"
-version = "0.11.0"
+version = "1.0.0"
 description = "Personal finance tracker with CSV import, smart categorization, and spending trend analysis."
 requires-python = ">=3.14"
 dependencies = [

--- a/docs-site/api/import.md
+++ b/docs-site/api/import.md
@@ -83,4 +83,5 @@ Content-Type: multipart/form-data
 | `venmo` | Venmo export |
 | `inspira_hsa` | Inspira HSA |
 | `qif` | Quicken Interchange Format |
-| `ofx` | Open Financial Exchange |
+| `qfx` | Quicken QFX / Open Financial Exchange (OFX) |
+| `custom` | User-defined CSV column mapping |

--- a/docs-site/api/overview.md
+++ b/docs-site/api/overview.md
@@ -16,26 +16,38 @@ All API endpoints are prefixed with `/api/v1/`.
 
 ## Authentication
 
-The API uses JWT-based authentication. On first run, you'll create a user account. All API requests require a valid Bearer token in the Authorization header.
+The API uses JWT-based authentication. On first run, you'll create a user
+account at `/setup`. After that, every request (except the auth and health
+endpoints) must include a valid Bearer token in the `Authorization` header:
 
-See the [Authentication](/api/auth) section for login endpoints and token management.
+```
+Authorization: Bearer <token>
+```
+
+Obtain a token from `POST /api/v1/auth/login`. See
+[Authentication](../getting-started/authentication.md) for the full login flow,
+password reset, and token configuration.
 
 ## Endpoint Groups
 
 | Group | Prefix | Description |
 |-------|--------|-------------|
+| Auth | `/api/v1/auth` | Setup, login, password, current user |
 | Transactions | `/api/v1/transactions` | CRUD operations, filtering, tagging |
 | Import | `/api/v1/import` | Import from CSV, QIF, QFX, OFX |
 | Reports | `/api/v1/reports` | Analytics, summaries, insights |
 | Budgets | `/api/v1/budgets` | Budget limits and tracking |
 | Recurring | `/api/v1/recurring` | Recurring transaction detection |
 | Tags | `/api/v1/tags` | Tag management (buckets, occasions, accounts) |
-| Category Rules | `/api/v1/category-rules` | Automated categorization |
+| Tag Rules | `/api/v1/tag-rules` | Automated categorization rules |
 | Transfers | `/api/v1/transfers` | Transfer detection and linking |
-| Merchants | `/api/v1/merchant-aliases` | Merchant name normalization |
+| Merchants | `/api/v1/merchants` | Merchant name normalization |
 | Accounts | `/api/v1/accounts` | Account management |
 | Filters | `/api/v1/filters` | Saved search filters |
-| Admin | `/api/v1/admin` | Data management |
+| Dashboards | `/api/v1/dashboards` | Multi-dashboard management |
+| Settings | `/api/v1/settings` | App settings, locale, backup schedule |
+| Assistant | `/api/v1/assistant` | AI assistant chat and approved actions |
+| Admin | `/api/v1/admin` | Data management and backups |
 
 ## Common Response Patterns
 

--- a/docs-site/api/transactions.md
+++ b/docs-site/api/transactions.md
@@ -40,7 +40,7 @@ GET /api/v1/transactions?skip=0&limit=100
 | `amount_min` | float | Minimum amount |
 | `amount_max` | float | Maximum amount |
 | `is_transfer` | bool | Filter by transfer status |
-| `reconciliation_status` | string | unreconciled, matched, ignored |
+| `reconciliation_status` | string | unreconciled, matched, manually_entered, ignored |
 
 ### Response
 

--- a/docs-site/developer/architecture.md
+++ b/docs-site/developer/architecture.md
@@ -9,7 +9,7 @@ Maxwell's Wallet is a full-stack application with a Python backend and TypeScrip
 | Frontend | Next.js 16 + TypeScript + Tailwind CSS 4 |
 | Backend | FastAPI + Python 3.11+ (async) |
 | Database | SQLite (dev) / PostgreSQL (prod) |
-| ORM | SQLModel (Pydantic + SQLAlchemy) |
+| ORM | SQLAlchemy 2.0 (async) + Pydantic schemas |
 | Charts | Recharts |
 | Package Management | npm (frontend), uv (backend) |
 
@@ -20,7 +20,9 @@ maxwells-wallet/
 ├── backend/                 # FastAPI backend
 │   ├── app/
 │   │   ├── main.py         # FastAPI app entry point
-│   │   ├── models.py       # SQLModel database models
+│   │   ├── orm.py          # SQLAlchemy 2.0 ORM models
+│   │   ├── schemas.py      # Pydantic request/response schemas
+│   │   ├── config.py       # Settings (env-driven AppSettings)
 │   │   ├── database.py     # Database configuration
 │   │   ├── tag_inference.py # Bucket tag inference
 │   │   ├── parsers/        # CSV/QIF/QFX parsing
@@ -36,6 +38,9 @@ maxwells-wallet/
 │   │   │   ├── middleware.py # Request instrumentation
 │   │   │   └── alerting.py # Webhook notifications
 │   │   └── routers/        # API route handlers
+│   │       ├── auth.py          # Setup, login, password
+│   │       ├── assistant.py     # AI assistant chat/execute
+│   │       ├── settings.py      # App settings, locale, backup schedule
 │   │       ├── transactions.py
 │   │       ├── tags.py
 │   │       ├── import_router.py
@@ -89,7 +94,8 @@ maxwells-wallet/
 The backend follows a router-based architecture with FastAPI:
 
 - **Routers** handle HTTP endpoints, grouped by domain
-- **Models** define SQLModel entities (Pydantic + SQLAlchemy hybrid)
+- **ORM models** (`orm.py`) define SQLAlchemy 2.0 entities
+- **Schemas** (`schemas.py`) define Pydantic request/response models
 - **Parsers** handle file format detection and parsing
 - **Utils** contain shared utilities (hashing, etc.)
 
@@ -97,6 +103,9 @@ The backend follows a router-based architecture with FastAPI:
 
 | Router | Purpose |
 |--------|---------|
+| `auth.py` | First-run setup, login, password management (JWT) |
+| `assistant.py` | AI assistant chat and approved-action execution |
+| `settings.py` | App settings, locale resolution, backup schedule |
 | `transactions.py` | Transaction CRUD, search, splits |
 | `dashboards.py` | Multi-dashboard management |
 | `dashboard.py` | Widget CRUD and layout |
@@ -112,8 +121,9 @@ The backend follows a router-based architecture with FastAPI:
 ### Key Patterns
 
 - **Async everywhere**: All database operations use async/await
-- **SQLModel**: Single model definitions serve as both Pydantic schemas and SQLAlchemy ORM models
+- **SQLAlchemy 2.0 + Pydantic**: ORM models in `orm.py`, separate Pydantic schemas in `schemas.py` for request/response validation
 - **Alembic**: Database migrations for schema changes
+- **JWT auth**: Single-user authentication via a Bearer token on every request
 - **Content hashing**: Dual-hash deduplication for reliable import
 
 ### Observability

--- a/docs-site/developer/database.md
+++ b/docs-site/developer/database.md
@@ -8,7 +8,7 @@ Database schema is managed with [Alembic](https://alembic.sqlalchemy.org/) migra
 
 ### Creating Migrations
 
-When you modify models in `backend/app/models.py`:
+When you modify ORM models in `backend/app/orm.py`:
 
 ```bash
 cd backend
@@ -47,22 +47,24 @@ Populate the database with sample transactions:
 just db::seed
 ```
 
-This imports sample CSV files from `/samples/` and creates default categories.
+This generates a set of realistic randomized transactions, accounts, and default
+buckets (via `backend/scripts/seed.py`) — no external files required.
 
 ### Reset Database
 
-To start fresh:
+To delete and recreate the database (init + seed), use the recipe, which prompts
+for confirmation:
 
 ```bash
 just db::reset
 ```
 
-Or manually:
+Equivalent manual steps:
 
 ```bash
-cd backend
-rm wallet.db
-uv run python -m app.seed
+rm -f backend/wallet.db
+just db::init   # create tables
+just db::seed   # generate sample data
 ```
 
 ## Database Location

--- a/docs-site/developer/i18n.md
+++ b/docs-site/developer/i18n.md
@@ -1,0 +1,66 @@
+# Internationalization (i18n)
+
+Maxwell's Wallet ships in 10 locales. The UI is fully localized with
+locale-aware date and currency formatting, powered by
+[next-intl](https://next-intl.dev/).
+
+## Supported Locales
+
+| Locale | Language |
+|--------|----------|
+| `en-US` | English (US) — source |
+| `en-GB` | English (UK) |
+| `es-ES` | Spanish |
+| `fr-FR` | French |
+| `it-IT` | Italian |
+| `pt-PT` | Portuguese |
+| `de-DE` | German |
+| `nl-NL` | Dutch |
+| `aa-ER` | Afar |
+| `pseudo` | Pseudo-locale (QA only) |
+
+Users pick a language in Settings, or leave it on "browser" to follow the
+`Accept-Language` header. Any translation key missing from a locale falls back to
+the English (`en-US`) string, so the UI never shows a raw key.
+
+## The Golden Rule
+
+**Only `frontend/src/messages/en-US.json` is hand-edited.** Every other locale
+file is managed by [Crowdin](https://crowdin.com/) and synced automatically — do
+not edit them by hand (a CI guard rejects PRs that do).
+
+## Adding Translatable Strings
+
+1. Add the English string to `frontend/src/messages/en-US.json` using dot-notation
+   keys (e.g. `admin.backups.createButton`).
+2. Use it in code via `useTranslations`:
+
+   ```tsx
+   import { useTranslations } from 'next-intl';
+
+   const t = useTranslations('admin.backups');
+   return <button>{t('createButton')}</button>;
+   ```
+
+3. Commit and push to `main`. A GitHub Action uploads the new source strings to
+   Crowdin; completed translations come back as a pull request.
+
+## Just Recipes
+
+| Command | Description |
+|---------|-------------|
+| `just i18n::upload` | Push `en-US.json` source strings to Crowdin |
+| `just i18n::download` | Pull translations from Crowdin |
+| `just i18n::status` | Show translation progress |
+| `just i18n::pseudo` | Regenerate the pseudo-locale for QA |
+
+## CI Safety Gates
+
+Translation completeness is enforced by tests in
+`frontend/src/test/i18n.test.ts`, which verify that every shipped locale has all
+keys from `en-US.json` and that ICU `{placeholder}` tokens are preserved. A
+separate guard workflow blocks direct edits to Crowdin-managed locale files.
+
+For the complete workflow — including Crowdin configuration, handling sync PRs,
+and providing translator context — see the in-repo
+[i18n workflow guide](https://github.com/poindexter12/maxwells-wallet/blob/main/docs/i18n-workflow.md).

--- a/docs-site/developer/observability.md
+++ b/docs-site/developer/observability.md
@@ -25,7 +25,7 @@ OTEL_METRICS_ENABLED=true
 
 # Logging
 OTEL_LOG_LEVEL=INFO
-OTEL_LOG_FORMAT=console  # or "json" for structured logs
+OTEL_LOG_FORMAT=json  # structured logs (default); use "console" for human-readable
 
 # Slow query detection threshold in milliseconds
 OTEL_SLOW_QUERY_THRESHOLD_MS=100

--- a/docs-site/developer/testing.md
+++ b/docs-site/developer/testing.md
@@ -69,14 +69,12 @@ just test::quality    # Full quality checks (lint + typecheck + vulture)
 
 ## Test Data
 
-### Quick Samples
+### Seeded Sample Data
 
-The `/samples/` directory contains sample CSV files for database seeding:
-
-- `bofa.csv` - Bank of America checking format
-- `amex.csv` - American Express format
-
-These are imported when running `just db::seed`.
+`just db::seed` generates realistic randomized transactions, accounts, and
+default buckets programmatically (via `backend/scripts/seed.py`). No external CSV
+files are required — running the recipe is enough to populate a local database
+for development and manual testing.
 
 ### Anonymizing Real Data
 

--- a/docs-site/domain-model.md
+++ b/docs-site/domain-model.md
@@ -52,10 +52,11 @@ Spending limits with tracking.
 
 | Field | Description |
 |-------|-------------|
-| `tag_namespace` | Which namespace to track (bucket, occasion, account) |
-| `tag_value` | Which tag value |
+| `tag` | Tag to track, as `namespace:value` (e.g. `bucket:groceries`) |
 | `amount` | Spending limit |
 | `period` | monthly or yearly |
+| `start_date` / `end_date` | Optional bounds for the budget window |
+| `rollover_enabled` | Carry unused amount into the next period |
 
 ### Dashboard
 

--- a/docs-site/features/assistant.md
+++ b/docs-site/features/assistant.md
@@ -1,0 +1,109 @@
+# AI Assistant
+
+Ask questions about your finances in plain language, and let the assistant propose changes you approve.
+
+## Overview
+
+The **Assistant** is an in-app chat page in the top navigation. You type a question in natural language ("How much did I spend on groceries last month?") and get an answer drawn from your own data. It can also **propose changes** — like a new budget or a recategorization — which it never applies on its own. You review and approve each proposal before anything takes effect.
+
+The assistant replies in your selected app language.
+
+## Bring Your Own Key (BYOK)
+
+The assistant works with either **Anthropic (Claude)** or **OpenAI**. You supply your own API key.
+
+!!! important "Keys live in the server environment only"
+    API keys are configured exclusively through server environment variables — never stored in the database and never sent to the browser. The in-app Assistant settings panel is **read-only**: it shows whether the assistant is configured, which provider is active, and which model is in use. There is no key entry field in the UI.
+
+### Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ANTHROPIC_API_KEY` | One key required | Your Anthropic (Claude) API key |
+| `OPENAI_API_KEY` | One key required | Your OpenAI API key |
+| `ASSISTANT_PROVIDER` | Optional | `anthropic` or `openai`. If unset, auto-detects from whichever key is present |
+| `ASSISTANT_MODEL` | Optional | Overrides the default model |
+
+Provide a key for the provider you want to use. The default model is `claude-sonnet-4-6` for Anthropic and `gpt-4o` for OpenAI.
+
+### Docker Compose example
+
+The app's compose files already pass these variables through, so you can set them in your shell or a `.env` file:
+
+```yaml
+services:
+  app:
+    image: ghcr.io/poindexter12/maxwells-wallet
+    environment:
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ASSISTANT_PROVIDER: ${ASSISTANT_PROVIDER:-}
+      ASSISTANT_MODEL: ${ASSISTANT_MODEL:-}
+```
+
+The `${VAR:-}` form leaves a variable empty when it isn't set, so you only need to define the key(s) you actually use.
+
+## Privacy
+
+Your real account, merchant, and person names never leave the machine.
+
+Before any data is sent to the LLM, the assistant replaces sensitive names with stable pseudonymous tokens:
+
+- Account names → `Account 1`, `Account 2`, …
+- Merchant / payee names → `Merchant 1`, `Merchant 2`, …
+- People's names → `Person 1`, `Person 2`, …
+
+The tokens are stable within a conversation, so the model can still reason about "Merchant 1" consistently. Numeric IDs, amounts, and dates pass through unchanged. **Raw transaction descriptions and memos are not sent at all.**
+
+When the model replies, the tokens are mapped back to your real names for display, so what you read uses the actual account and merchant names.
+
+!!! note
+    Net effect: the LLM provider sees pseudonyms and numbers, never your real account, merchant, or person names — and never your raw transaction descriptions.
+
+## What It Can Do
+
+### Read-only questions
+
+These run automatically — there is nothing to approve, because nothing changes. The assistant can answer questions about:
+
+- Spending summaries
+- Spending by category or bucket
+- Top merchants
+- Transactions
+- Budgets
+- Tags
+- Dashboards
+
+### Proposed changes
+
+The assistant can propose the following, but **never executes them automatically** — you approve each proposal:
+
+- Create or update **budgets**
+- **Categorize** transactions by applying bucket tags
+- Create or update **dashboards** and widgets
+
+## What It Will Not Do
+
+!!! warning "Hard limits"
+    The assistant has no tools for these actions, so it cannot perform them under any circumstances:
+
+    - Create, edit, or delete transactions
+    - Move money
+    - Import data
+    - Change accounts or settings
+
+## Approval Flow
+
+When the assistant proposes changes, they appear as a plain-language list with two buttons:
+
+- **Execute** — apply the proposed changes
+- **Dismiss** — discard them
+
+Nothing happens until you click **Execute**. Read-only answers never trigger this flow.
+
+## How to Use
+
+1. Open **Assistant** in the top navigation.
+2. If it isn't configured yet, the panel tells you to set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` in the server environment (see [Bring Your Own Key](#bring-your-own-key-byok)).
+3. Ask a question, for example: *"How much did I spend on groceries last month?"*
+4. If the assistant proposes changes, review the list and click **Execute** to apply them or **Dismiss** to discard.

--- a/docs-site/features/import.md
+++ b/docs-site/features/import.md
@@ -21,7 +21,6 @@ No manual format selection required for supported formats.
 | Bank of America (Checking) | "Running Bal." column |
 | Bank of America (Credit Card) | "Posted Date" + "Reference Number" |
 | American Express | "Card Member" + "Account #" |
-| Chase | Chase-specific headers |
 | Venmo | Venmo-specific headers |
 | Inspira HSA | Inspira-specific headers |
 | Custom CSV | User-defined column mapping |

--- a/docs-site/getting-started/authentication.md
+++ b/docs-site/getting-started/authentication.md
@@ -1,0 +1,78 @@
+# Authentication
+
+Maxwell's Wallet is a single-user application protected by a username and
+password. Access is gated by a JSON Web Token (JWT) issued at login, so every
+API request after setup must carry a valid token.
+
+## First-Run Setup
+
+On the very first launch no user exists yet, so the app redirects you to
+`/setup`:
+
+1. Open the app at `http://localhost:3000`
+2. You are redirected to `/setup`
+3. Choose a username and password
+4. You are logged in automatically and a session token is stored in your browser
+
+Once a user exists, `/setup` is closed — the setup endpoint only succeeds when
+the database has no users.
+
+## Logging In
+
+After setup, visiting the app while logged out shows the login screen. Enter
+your username and password to receive a fresh session token. Tokens expire after
+`TOKEN_EXPIRE_HOURS` (one week by default); after that you log in again.
+
+## Changing Your Password
+
+Change your password from the UI while logged in (Settings → account). This
+requires your current password.
+
+## Resetting a Forgotten Password (CLI)
+
+If you are locked out, reset the password from the container — no UI access
+required:
+
+```bash
+# Against a running container
+docker compose exec maxwells-wallet reset-password <username> <new_password>
+
+# Or a one-off container
+docker compose run --rm maxwells-wallet reset-password <username> <new_password>
+```
+
+## Configuration
+
+JWTs are signed with `SECRET_KEY`. The default is a development placeholder, so
+**always set a strong, random `SECRET_KEY` in production** — otherwise tokens are
+forgeable.
+
+```bash
+docker run -d -p 3000:3000 -p 3001:3001 \
+  -e SECRET_KEY="$(openssl rand -hex 32)" \
+  -v /path/to/data:/data \
+  ghcr.io/poindexter12/maxwells-wallet
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SECRET_KEY` | dev placeholder | JWT signing key. **Set in production.** |
+| `TOKEN_EXPIRE_HOURS` | `168` (1 week) | Session token lifetime in hours |
+
+Changing `SECRET_KEY` invalidates all existing sessions, requiring everyone to
+log in again.
+
+## Auth API
+
+The auth endpoints live under `/api/v1/auth`:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/v1/auth/status` | Whether a user exists and whether the request is authenticated |
+| POST | `/api/v1/auth/setup` | Create the first user (only when none exists) |
+| POST | `/api/v1/auth/login` | Authenticate and receive a JWT |
+| GET | `/api/v1/auth/me` | Current authenticated user info |
+| PUT | `/api/v1/auth/password` | Change the current user's password |
+
+All other API requests require an `Authorization: Bearer <token>` header. See the
+[API Overview](../api/overview.md) for details.

--- a/docs-site/getting-started/development.md
+++ b/docs-site/getting-started/development.md
@@ -28,18 +28,15 @@ just dev::dev
 ```bash
 cd backend
 
-# Create virtual environment
-uv venv
-source .venv/bin/activate
+# Install dependencies (uv sync creates the .venv for you)
+uv sync --all-extras
 
-# Install dependencies
-uv pip install -e .
+# Create tables, then seed sample data
+uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"
+uv run python -m scripts.seed
 
-# Seed database
-uv run python -m app.seed
-
-# Start server
-uv run uvicorn app.main:app --reload --port 8000
+# Start server (backend listens on port 3001)
+uv run uvicorn app.main:app --reload --port 3001
 ```
 
 ### Frontend
@@ -65,6 +62,15 @@ just utils::status      # Check if servers running
 ```
 
 ## Database Migrations
+
+Prefer the `just` recipes, which handle paths and environment setup:
+
+```bash
+just db::migrate MESSAGE="description"  # Create a new migration
+just db::upgrade                        # Apply migrations
+```
+
+Equivalent manual commands:
 
 ```bash
 cd backend

--- a/docs-site/getting-started/docker.md
+++ b/docs-site/getting-started/docker.md
@@ -31,14 +31,90 @@ docker run -d \
 
 ## Environment Variables
 
+All settings can be supplied via the environment (e.g. in your compose file or
+an `.env` file). The most common ones:
+
+### Core
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DATABASE_URL` | `sqlite:///data/wallet.db` | Database connection string |
-| `DEMO_MODE` | `false` | Enable demo mode restrictions |
+| `DATABASE_URL` | `sqlite+aiosqlite:////data/wallet.db` | Database connection string (async SQLite by default) |
+
+### Authentication
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SECRET_KEY` | `change-me-in-production-...` | JWT signing key. **Set a long random value in production.** |
+| `TOKEN_EXPIRE_HOURS` | `168` (1 week) | How long a login session token stays valid |
+
+See [Authentication](authentication.md) for the first-run setup and password reset.
+
+### AI Assistant
+
+The assistant is configured entirely through the environment — nothing is
+persisted to the database, and keys are never returned to the browser. Provide a
+key for whichever provider you want; the provider auto-detects from the key
+present, or set `ASSISTANT_PROVIDER` to choose explicitly.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | _(empty)_ | Enables the assistant using Anthropic models |
+| `OPENAI_API_KEY` | _(empty)_ | Enables the assistant using OpenAI models |
+| `ASSISTANT_PROVIDER` | _(auto-detect)_ | `anthropic` or `openai` to force a provider |
+| `ASSISTANT_MODEL` | _(provider default)_ | Optional model override |
+
+If no key is set, the assistant UI simply reports that it is not configured. See
+the [Assistant](../features/assistant.md) guide for details.
+
+### Demo Mode
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEMO_MODE` | `false` | Block destructive operations and show a demo banner |
+| `DEMO_RESET_INTERVAL_HOURS` | `1` | Hours between demo data resets |
+
+### Backups
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BACKUP_DIR` | `./data/backups` | Directory for backup files |
+| `BACKUP_RETENTION` | `10` | Number of backups to keep (0 = unlimited) |
+| `BACKUP_RETENTION_DAYS` | `0` | Delete backups older than N days (0 = disabled) |
+| `AUTO_BACKUP_ENABLED` | `false` | Enable scheduled automatic backups |
+| `AUTO_BACKUP_INTERVAL_HOURS` | `24` | Hours between automatic backups |
+
+### Observability
+
+OpenTelemetry tracing/metrics are configured via `OTEL_*` variables — see
+[Observability](../developer/observability.md) for the full list.
+
+### CORS
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CORS_ORIGINS` | `http://localhost:3000` | Comma-separated list of allowed origins |
+
+## Container Commands
+
+The all-in-one image accepts subcommands in addition to the default start:
+
+```bash
+docker compose run --rm maxwells-wallet migrate                       # Run migrations
+docker compose run --rm maxwells-wallet seed                          # Seed sample data
+docker compose run --rm maxwells-wallet demo-setup                    # Seed + create demo backup
+docker compose run --rm maxwells-wallet reset-password <user> <pass>  # Reset a password
+```
 
 ## Building from Source
 
 ```bash
 docker compose -f docker-compose.dev.yaml build
 docker compose -f docker-compose.dev.yaml up -d
+```
+
+Or with the `just` recipes:
+
+```bash
+just docker::build
+just docker::up
 ```

--- a/docs-site/getting-started/quickstart.md
+++ b/docs-site/getting-started/quickstart.md
@@ -15,10 +15,12 @@ Your data is persisted in a Docker volume. To use a custom location:
 
 ```bash
 docker run -d \
-  -p 3000:3000 -p 8000:8000 \
+  -p 3000:3000 -p 3001:3001 \
   -v /path/to/your/data:/data \
   ghcr.io/poindexter12/maxwells-wallet
 ```
+
+The app serves the frontend on port `3000` and the backend API on port `3001`.
 
 ## Using Just (Development)
 
@@ -34,7 +36,7 @@ just dev::dev
 
 ## First Steps
 
-1. **Create account**: On first launch, you'll be redirected to `/setup` to create your username and password
+1. **Create account**: On first launch, you'll be redirected to `/setup` to create your username and password (see [Authentication](authentication.md))
 2. **Import transactions**: Go to the Import page and upload a CSV, QIF, or QFX file
 3. **Categorize**: Assign bucket tags to organize your spending
 4. **Set budgets**: Create spending limits on the Budgets page
@@ -42,11 +44,20 @@ just dev::dev
 
 ## Demo Mode
 
-Try Maxwell's Wallet without setting up your own data:
+Try Maxwell's Wallet without committing your own data. Demo mode seeds sample
+transactions, blocks destructive actions, and resets on a schedule.
 
 ```bash
+# Build from source and start in demo mode
 just docker::with-demo
-# Login: maxwell / wallet
+```
+
+The first time you start a demo instance, create an account at `/setup` like any
+other install, then seed the demo data. With the published image:
+
+```bash
+docker compose -f docker-compose.demo.yaml up -d
+docker compose -f docker-compose.demo.yaml run --rm maxwells-wallet demo-setup
 ```
 
 ## Supported Import Formats

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -5,22 +5,17 @@ Personal finance tracker with CSV import, smart categorization, and spending tre
 [![CI](https://github.com/poindexter12/maxwells-wallet/actions/workflows/ci.yaml/badge.svg)](https://github.com/poindexter12/maxwells-wallet/actions/workflows/ci.yaml)
 [![Release](https://img.shields.io/github/v/release/poindexter12/maxwells-wallet?label=release)](https://github.com/poindexter12/maxwells-wallet/releases)
 
-## What's New in v0.11
+## What's New in 1.0.0
 
-### SQLAlchemy 2.0 Migration
-- **ORM Upgrade** - Migrated from SQLModel to SQLAlchemy 2.0 + Pydantic for improved type safety and performance
+### AI Assistant
+- **Natural-Language Assistant** - Ask about your finances and propose changes in plain language; reads run automatically while writes require explicit approval. See the [Assistant](features/assistant.md) guide.
 
-### Performance & Stability
-- **Transactions Page** - Debouncing and request cancellation prevent UI lag
-- **Chaos Tests** - Viewport-based demon mode for reliable stress testing
-
-### v0.10 Highlights
-- **Single-User Auth** - Password protection with JWT tokens and first-run setup
+### Foundations
+- **Single-User Auth** - Password protection with JWT tokens and a first-run `/setup` flow. See [Authentication](getting-started/authentication.md).
+- **SQLAlchemy 2.0** - ORM built on SQLAlchemy 2.0 + Pydantic for type safety and performance
 - **Demo Mode** - Public demo instances with restricted operations and auto-reset
 - **Backup System** - SQLite backup/restore with GFS retention and scheduled backups
-
-### v0.9 Highlights
-- **9 Locales** - Full i18n support with locale-aware date and currency formatting
+- **10 Locales** - Full i18n support (managed via Crowdin) with locale-aware date and currency formatting
 
 ## Features
 
@@ -43,6 +38,10 @@ Personal finance tracker with CSV import, smart categorization, and spending tre
 - **Saved Filters**: Save and reuse complex filter combinations
 - **CSV Export**: Export filtered transactions
 - **Dynamic Thresholds**: "Large" personalized to your spending
+
+### AI Assistant & Security
+- **AI Assistant**: Ask questions about your spending in plain language; writes require approval
+- **Single-User Auth**: Password-protected access with JWT sessions and first-run setup
 
 ## Quick Start
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maxwells-wallet-frontend",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--disable-warning=DEP0060' next dev",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Home: index.md
   - Getting Started:
     - Quick Start: getting-started/quickstart.md
+    - Authentication: getting-started/authentication.md
     - Docker Setup: getting-started/docker.md
     - Development Setup: getting-started/development.md
   - Features:
@@ -42,6 +43,7 @@ nav:
     - Budgets: features/budgets.md
     - Dashboards: features/dashboards.md
     - Analytics: features/analytics.md
+    - Assistant: features/assistant.md
   - API Reference:
     - Overview: api/overview.md
     - Transactions: api/transactions.md
@@ -50,6 +52,7 @@ nav:
   - Developer Guide:
     - Architecture: developer/architecture.md
     - Database: developer/database.md
+    - Internationalization: developer/i18n.md
     - Observability: developer/observability.md
     - Testing: developer/testing.md
   - Domain Model: domain-model.md


### PR DESCRIPTION
Cuts the **1.0.0** release.

## Docs (published help site + repo)
- **New** `features/assistant.md` — BYOK env config, PII tokenization, propose-and-approve capabilities, language.
- **New** `getting-started/authentication.md` and `developer/i18n.md`.
- **Full gaps audit + fixes** across getting-started / features / api / developer / domain-model (ports 3000/3001, `just` commands, SQLAlchemy 2.0, auth, assistant env vars, i18n English fallback).
- **README** — 'What's New in v1.0', Features → AI Assistant, Configuration → assistant env vars.
- **CHANGELOG** — `[1.0.0]` consolidating: AI assistant (#335, #338), i18n resilience (#339, #340), cross-arch Docker build (#341), arm64 CI (#342).
- `mkdocs build --strict` passes.

## Version
- `0.11.0` → `1.0.0` (`backend/pyproject.toml` + `frontend/package.json`). `just release::validate` passes.

## Release mechanics
After merge, pushing the `v1.0.0` tag triggers `release.yaml` (GitHub Release from the CHANGELOG) — done as a separate, explicitly-confirmed step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)