### PR TITLE
chore: re-version release to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-05-26
+## [1.3.0] - 2026-05-26
 
-First stable release. Maxwell's Wallet 1.0 ships the full feature set: CSV/QFX/QIF import, transaction management, budgets, customizable dashboards, analytics, recurring detection, transfer detection, tagging, single-user authentication, the new AI assistant, 10-language internationalization, and built-in observability.
+Headlined by the new AI assistant. Maxwell's Wallet now spans the full feature set: CSV/QFX/QIF import, transaction management, budgets, customizable dashboards, analytics, recurring detection, transfer detection, tagging, single-user authentication, the AI assistant, 10-language internationalization, and built-in observability.
 
 ### Added
 - **AI Assistant (bring-your-own-key)** - In-app chat assistant backed by Anthropic (Claude) or OpenAI, configured entirely via server environment variables (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`, optional `ASSISTANT_PROVIDER`/`ASSISTANT_MODEL`) — nothing is persisted (PRs #335, #338)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Personal finance tracker with CSV import, smart categorization, and spending tre
 
 **[Documentation](https://docs.maxwellswallet.com)** · **[Requirements](docs/requirements/)**
 
-## What's New in v1.0
+## What's New in v1.3
 
-Maxwell's Wallet 1.0 is the first stable release, bringing the full feature set together: CSV/QFX/QIF import, transactions, budgets, dashboards, analytics, recurring detection, transfers, tagging, single-user auth, 10-language i18n, observability — and the new AI Assistant.
+Maxwell's Wallet 1.3 is headlined by the new AI Assistant, on top of the full feature set: CSV/QFX/QIF import, transactions, budgets, dashboards, analytics, recurring detection, transfers, tagging, single-user auth, 10-language i18n, and observability.
 
 ### AI Assistant (Bring Your Own Key)
 - **In-App Chat** - Ask questions about your finances and get answers powered by Anthropic (Claude) or OpenAI

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maxwells-wallet-backend"
-version = "1.0.0"
+version = "1.3.0"
 description = "Personal finance tracker with CSV import, smart categorization, and spending trend analysis."
 requires-python = ">=3.14"
 dependencies = [

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -5,7 +5,7 @@ Personal finance tracker with CSV import, smart categorization, and spending tre
 [![CI](https://github.com/poindexter12/maxwells-wallet/actions/workflows/ci.yaml/badge.svg)](https://github.com/poindexter12/maxwells-wallet/actions/workflows/ci.yaml)
 [![Release](https://img.shields.io/github/v/release/poindexter12/maxwells-wallet?label=release)](https://github.com/poindexter12/maxwells-wallet/releases)
 
-## What's New in 1.0.0
+## What's New in 1.3.0
 
 ### AI Assistant
 - **Natural-Language Assistant** - Ask about your finances and propose changes in plain language; reads run automatically while writes require explicit approval. See the [Assistant](features/assistant.md) guide.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maxwells-wallet-frontend",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--disable-warning=DEP0060' next dev",


### PR DESCRIPTION
The previous release was mistakenly cut as **1.0.0**, but the repo's release line is at **v1.2** — so this is **v1.3**.

- Backend/frontend version `1.0.0` → `1.3.0`
- CHANGELOG section `[1.0.0]` → `[1.3.0]`; README + docs 'What's New' headings → v1.3
- Dropped the inaccurate 'first stable release' framing (v1.0–v1.2 already shipped)

The mistaken `v1.0.0` GitHub Release + tag are already deleted. After this merges, the `v1.3` tag is pushed to cut the corrected release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)