### PR TITLE
fix(ci): generate pseudo-locale before nightly E2E tests

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -51,6 +51,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate pseudo-locale for i18n E2E tests
+        run: just i18n::pseudo
+
       - name: Install Playwright browsers
         working-directory: frontend
         run: |


### PR DESCRIPTION
## Summary
Nightly E2E (`E2E Tests (All Browsers)`) has been failing on `i18n-coverage.spec.ts:63 — NavBar items should be pseudo-localized`. Root cause: `src/messages/pseudo.json` is `.gitignore`'d and must be generated at build time by `node scripts/generate-pseudo-locale.mjs` (via `just i18n::pseudo`).

`ci.yaml` already runs that step before its E2E job (line 117-118), which is why PR CI is green. `nightly-e2e.yaml` was missing it, so next-intl falls back to English at runtime and the accented-char regex in the test fails on chromium / firefox / webkit.

## Changes
- `.github/workflows/nightly-e2e.yaml`: add `just i18n::pseudo` between `install-frontend` and `playwright install`, mirroring the working step in `ci.yaml`.

## Test plan
- [ ] CI E2E job passes (sanity — the step is already in `ci.yaml`, so this is unchanged for PRs)
- [ ] Manually `workflow_dispatch` `E2E Tests (All Browsers)` on this branch and confirm `i18n Coverage (Pseudo-Locale) › NavBar items should be pseudo-localized` passes on chromium, firefox, and webkit
- [ ] Confirm `src/messages/pseudo.json` is present in the workflow runner after the new step


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJZYVbFGqQSbiwLCMDyNc5)_